### PR TITLE
add social registration

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -36,6 +36,7 @@ class User extends Authenticatable
         'tfa_secret',
         'role_id',
         'credits',
+        'is_social_user',
     ];
 
     /**

--- a/database/migrations/2023_08_12_042535_add_is_social_user_column_to_users.php
+++ b/database/migrations/2023_08_12_042535_add_is_social_user_column_to_users.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIsSocialUserColumnToUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_social_user')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_social_user');
+        });
+    }
+};


### PR DESCRIPTION
When a social user logs it, it creates an account for them using their email. 

If the user goes to a page that requires a password auth, it bypasses the check. (Could force them to relogin with the social, seemed like a bit much for my needs)

Added migration to have a "is_social_user" flag set during registration. 