### PR TITLE
Remove check to not return free product invoices. 

### DIFF
--- a/app/Models/OrderProduct.php
+++ b/app/Models/OrderProduct.php
@@ -87,8 +87,6 @@ class OrderProduct extends Model
     public function getOpenInvoices()
     {
         return $this->getInvoices->filter(function ($invoice) {
-            if ($invoice->total() == 0)
-                return false;
             return $invoice->status == 'pending';
         });
     }


### PR DESCRIPTION
Already checks if the total is 0 in the cronjob, this check is redundant and will cause a loop if you try to invoice free products as it will never return an already existing invoice for a free product