### PR TITLE
Change default sort order to latest ID

### DIFF
--- a/app/Livewire/Admin/Clients/Index.php
+++ b/app/Livewire/Admin/Clients/Index.php
@@ -21,7 +21,6 @@ class Index extends DataTableComponent
     public function configure(): void
     {
         $this->setPrimaryKey('id')->setTableRowUrl(fn ($row) => route('admin.clients.edit', $row));
-
     }
 
     public function columns(): array

--- a/app/Livewire/Admin/Clients/Index.php
+++ b/app/Livewire/Admin/Clients/Index.php
@@ -20,7 +20,8 @@ class Index extends DataTableComponent
 
     public function configure(): void
     {
-        $this->setPrimaryKey('id')->setTableRowUrl(fn ($row) => route('admin.clients.edit', $row));
+        $this->setPrimaryKey('id')->setTableRowUrl(fn ($row) => route('admin.clients.edit', $row))
+        ->setDefaultSort('id', 'desc');
     }
 
     public function columns(): array

--- a/app/Livewire/Admin/Clients/Index.php
+++ b/app/Livewire/Admin/Clients/Index.php
@@ -20,8 +20,8 @@ class Index extends DataTableComponent
 
     public function configure(): void
     {
-        $this->setPrimaryKey('id')->setTableRowUrl(fn ($row) => route('admin.clients.edit', $row))
-        ->setDefaultSort('id', 'desc');
+        $this->setPrimaryKey('id')->setTableRowUrl(fn ($row) => route('admin.clients.edit', $row));
+
     }
 
     public function columns(): array

--- a/app/Livewire/Admin/Invoices/Index.php
+++ b/app/Livewire/Admin/Invoices/Index.php
@@ -26,7 +26,9 @@ class Index extends DataTableComponent
 
     public function configure(): void
     {
-        $this->setPrimaryKey('id')->setTableRowUrl(fn ($row) => route('admin.invoices.show', $row));
+        $this->setPrimaryKey('id')
+             ->setTableRowUrl(fn ($row) => route('admin.invoices.show', $row))
+             ->setDefaultSort('id', 'desc');
     }
 
     public function deleteInvoices(): void

--- a/app/Livewire/Admin/Orders/Index.php
+++ b/app/Livewire/Admin/Orders/Index.php
@@ -26,7 +26,8 @@ class Index extends DataTableComponent
 
     public function configure(): void
     {
-        $this->setPrimaryKey('id')->setTableRowUrl(fn ($row) => route('admin.orders.show', $row));
+        $this->setPrimaryKey('id')->setTableRowUrl(fn ($row) => route('admin.orders.show', $row))
+        ->setDefaultSort('id', 'desc');
     }
 
     public function deleteOrders(): void


### PR DESCRIPTION
Changes default sort order for Invoices, Orders and Clients to be sorted by the latest ID by default. 