### PR TITLE
Update order config key value types

### DIFF
--- a/database/migrations/2024_01_15_164416_update_order_products_config_key_value_type.php
+++ b/database/migrations/2024_01_15_164416_update_order_products_config_key_value_type.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('order_products_config', function (Blueprint $table) {
+            $table->text('key')->change();
+            $table->text('value')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('order_products_config', function (Blueprint $table) {
+            $table->string('key')->change();
+            $table->string('value')->change();
+        });
+    }
+};


### PR DESCRIPTION
This PR will fix issues that third party extensions may have when dealing with data longer than 119 characters. For example an RSA SSH-key can be more than 119 characters which will cause the extension to not function properly