### PR TITLE
Color errors red and no longer make use of the `$DEFAULT_URL` variable.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -5,9 +5,12 @@ URL='https://github.com/paymenter/paymenter/releases/latest/download/paymenter.t
 echo "Starting upgrade process..."
 
 if [ "$(php -r 'echo version_compare(PHP_VERSION, "8.1.0");')" -lt 0 ]; then
-    echo "Cannot execute self-upgrade process. The minimum required PHP version required is 8.1, you have [$(php -r 'echo PHP_VERSION;')]."
+    echo -e "\x1b[31;1mCannot execute self-upgrade process. The minimum required PHP version required is 8.1, you have [$(php -r 'echo PHP_VERSION;')].\x1b[0m"
     exit 1
 fi
+
+# Exit if release URL is empty or underfined
+if [[ $URL == "" ]]; then echo -e "\x1b[31;1mRelease URL not defined.\x1b[0m"; exit 1; fi
 
 for i in "$@"
 do
@@ -69,20 +72,13 @@ if [ -t 0 ]; then
     fi
 fi
 
-# Set URL to the default URL if not set.
-if [ -z "$URL" ]; then
-    DEFAULT_URL="https://github.com/paymenter/paymenter/releases/latest/download/paymenter.tar.gz"
-else
-    DEFAULT_URL="$URL"
-fi
-
 RUN() {
     echo -e "\x1b[34m\$\x1b[34;1mupgrader>\x1b[0m $*"
     "${@}"
 }
 
 # Download the latest release from GitHub.
-RUN curl -L "$(printf "%s" "$DEFAULT_URL")" | tar -xzv
+RUN curl -L "$(printf "%s" "$URL")" | tar -xzv
 
 # Set application down for maintenance.
 RUN php artisan down

--- a/update.sh
+++ b/update.sh
@@ -78,7 +78,7 @@ RUN() {
 }
 
 # Download the latest release from GitHub.
-RUN curl -L -o paymenter.tar.gz "$DEFAULT_URL"
+RUN curl -L -o paymenter.tar.gz "$URL"
 
 # Extract the tarball.
 RUN tar -xzf paymenter.tar.gz


### PR DESCRIPTION
Currently there are two variables for defining the release URL for the `update.sh` script assigned the following values:

`$URL` https://github.com/paymenter/paymenter/releases/latest/download/paymenter.tar.gz
`$DEFAULT_URL` https://github.com/paymenter/paymenter/releases/latest/download/paymenter.tar.gz

When `$URL` is empty, the value of `$DEFAULT_URL` gets assigned to `$URL`, but this never happens unless made completely empty by editing the file rendering a specific "if" statement completely useless.

The changes made in this pull request will instead throw an error when `$URL` is empty, which only happens if a user would edit the file and remove the value of `$URL`. I've also colored errors red because why not.