### PR TITLE
Fix department indexing inconsistency between admin and user dashboards

### DIFF
--- a/app/Admin/Resources/TicketResource.php
+++ b/app/Admin/Resources/TicketResource.php
@@ -153,7 +153,10 @@ class TicketResource extends Resource
                     })
                     ->formatStateUsing(fn (string $state) => ucfirst($state)),
                 Tables\Columns\TextColumn::make('department')
-                    ->formatStateUsing(fn ($state) => ((array) config('settings.ticket_departments'))[$state])
+                    ->formatStateUsing(function ($state) { 
+                    $departments = (array) config('settings.ticket_departments');
+                    return $departments[$state] ?? $departments[0];
+                    })
                     ->sortable(),
                 Tables\Columns\TextColumn::make('user.name')
                     ->searchable()

--- a/app/Classes/Settings.php
+++ b/app/Classes/Settings.php
@@ -411,6 +411,7 @@ class Settings
                     'label' => 'Ticket Departments',
                     'type' => 'tags',
                     'default' => ['Support', 'Sales'],
+                    'required' => true,
                     'database_type' => 'array',
                 ],
                 [

--- a/app/Livewire/Tickets/Create.php
+++ b/app/Livewire/Tickets/Create.php
@@ -59,7 +59,7 @@ class Create extends Component
 
         $ticket = Ticket::create([
             'user_id' => Auth::id(),
-            'department' => $this->department,
+            'department' => (int) array_search($this->department, config('settings.ticket_departments'), true) ,
             'service_id' => $this->service,
             'subject' => $this->subject,
             'priority' => $this->priority,


### PR DESCRIPTION

- Resolved an issue where the department was stored as an index in the admin dashboard and as a string in the user dashboard.
- Updated code to consistently handle the department using an integer index across both dashboards.
-  The department is now stored as the index in the database.