### PR TITLE
feat: allow users to download invoices pdf

### DIFF
--- a/app/Admin/Resources/InvoiceResource/Pages/EditInvoice.php
+++ b/app/Admin/Resources/InvoiceResource/Pages/EditInvoice.php
@@ -21,7 +21,7 @@ class EditInvoice extends EditRecord
                 ->action(function (Invoice $invoice) {
                     return response()->streamDownload(function () use ($invoice) {
                         echo PDF::generateInvoice($invoice)->stream();
-                    }, 'invoice.pdf');
+                    }, 'invoice-' . $invoice->id . '.pdf');
                 }),
         ];
     }

--- a/app/Livewire/Invoices/Show.php
+++ b/app/Livewire/Invoices/Show.php
@@ -9,6 +9,7 @@ use App\Models\Invoice;
 use Illuminate\Support\Facades\Request;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Url;
+use App\Classes\PDF;
 
 class Show extends Component
 {
@@ -87,5 +88,12 @@ class Show extends Component
         return view('invoices.show')->layoutData([
             'title' => __('invoices.invoice', ['id' => $this->invoice->id]),
         ]);
+    }
+
+    public function downloadPDF()
+    {
+        return response()->streamDownload(function () {
+            echo PDF::generateInvoice($this->invoice)->stream();
+        }, 'invoice-' . $this->invoice->id . '.pdf');
     }
 }

--- a/themes/default/views/invoices/show.blade.php
+++ b/themes/default/views/invoices/show.blade.php
@@ -187,5 +187,12 @@
         @endif
 
     </div>
+    <div class="flex justify-end">
+        <div class="max-w-[200px] w-full">
+            <x-button.primary wire:click="downloadPDF" class="mt-4">
+                Download PDF
+            </x-button.primary>
+        </div>
+    </div>
 
 </div>

--- a/themes/default/views/invoices/show.blade.php
+++ b/themes/default/views/invoices/show.blade.php
@@ -19,6 +19,14 @@
             </x-slot>
         </x-modal>
     @endif
+    <div class="flex justify-end">
+        <div class="max-w-[200px] w-full text-right">
+            <span class="cursor-pointer text-gray-400 underline" wire:click="downloadPDF">
+                Download PDF
+            </span>
+        </div>
+    </div>
+    
     <div class="bg-primary-800 p-12 rounded-lg mt-2">
         <div class="sm:flex justify-between pr-4 pt-4">
             <h1 class="text-2xl font-bold sm:text-3xl">{{ __('invoices.invoice', ['id' => $invoice->id]) }}</h1>
@@ -186,13 +194,6 @@
             </div>
         @endif
 
-    </div>
-    <div class="flex justify-end">
-        <div class="max-w-[200px] w-full">
-            <x-button.primary wire:click="downloadPDF" class="mt-4">
-                Download PDF
-            </x-button.primary>
-        </div>
     </div>
 
 </div>


### PR DESCRIPTION
Allows users to download invoices pdf and also adds invoice id in the pdf name.
![image](https://github.com/user-attachments/assets/aa9343f9-bb56-47e4-b3d0-cf8c22554774)
