### PR TITLE
Fix: Turnstile width/dark mode issues

### DIFF
--- a/themes/default/views/components/captcha/index.blade.php
+++ b/themes/default/views/components/captcha/index.blade.php
@@ -1,5 +1,5 @@
 @if (config('settings.captcha') !== 'disabled')
-    <div class="flex flex-col items-center justify-center mt-2">
+    <div class="flex flex-col justify-center mt-2">
         <div wire:ignore>
             @if (config('settings.captcha') == 'recaptcha-v2')
                 <x-captcha.recaptcha-v2 :$form />

--- a/themes/default/views/components/captcha/turnstile.blade.php
+++ b/themes/default/views/components/captcha/turnstile.blade.php
@@ -4,7 +4,7 @@
 
 <script>
     function renderTurnstile() {
-        const isDarkMode = document.documentElement.classList.contains('dark');
+        const isDarkMode = document.body.classList.contains('dark');
         const theme = isDarkMode ? 'dark' : 'light';
 
         turnstile.render('#cf-turnstile', {


### PR DESCRIPTION
With the change to dark mode on the body, it seems to have stopped working. I haven’t tested it but it should work. Also, the `items-center` is removed which was preventing full width for Turnstile.

![image](https://github.com/user-attachments/assets/9b20845f-9e8d-4123-a7de-946481ee8850)


![image](https://github.com/user-attachments/assets/0c1f97aa-0186-4df2-845c-3b4c2f08df8c)

