### PR TITLE
fix: resolve 500 error when sorting tickets by customer name

### DIFF
--- a/app/Admin/Resources/TicketResource.php
+++ b/app/Admin/Resources/TicketResource.php
@@ -155,8 +155,8 @@ class TicketResource extends Resource
                     ->formatStateUsing(fn ($state) => array_combine(config('settings.ticket_departments'), config('settings.ticket_departments'))[$state])
                     ->sortable(),
                 Tables\Columns\TextColumn::make('user.name')
-                    ->searchable()
-                    ->sortable(),
+                    ->searchable(['first_name', 'last_name'])
+                    ->sortable(['first_name', 'last_name']),
             ])
             ->filters([
                 //


### PR DESCRIPTION
This PR fixes a server-side 500 Internal Server Error that occurred when sorting tickets by customer name or filtering tickets by user in the search box.

The error was caused by a subquery attempting to select a name column from the users table, which doesn’t exist. The SQL error was:

`SQLSTATE[42S22]: Column not found: 1054 Unknown column 'name' in 'SELECT'`