### PR TITLE
Fix incorrect auto-closing logic for replied tickets in CronJob

### DIFF
--- a/app/Console/Commands/CronJob.php
+++ b/app/Console/Commands/CronJob.php
@@ -130,7 +130,8 @@ class CronJob extends Command
         // Close tickets if no response for x days
         $ticketClosed = 0;
         Ticket::where('status', 'replied')->each(function ($ticket) use (&$ticketClosed) {
-            if ($ticket->messages()->where('user_id', '!=', $ticket->user_id)->where('created_at', '<', now()->subDays((int) config('settings.cronjob_close_ticket')))->exists()) {
+            $lastMessage = $ticket->messages()->latest('created_at')->first();
+            if ($lastMessage && $lastMessage->created_at < now()->subDays((int) config('settings.cronjob_close_ticket'))) {
                 $ticket->update(['status' => 'closed']);
                 $ticketClosed++;
             }


### PR DESCRIPTION
Description:
This PR fixes the logic for automatically closing tickets with replied status after the configured time period.

What was wrong:
The original logic checked whether any message not from the ticket owner was older than the configured days. This could incorrectly close tickets just because the ticket was created a long time ago, even if the last reply was recent.

What’s changed:
Now, the script checks the timestamp of the last message, and only closes the ticket if that last message is older than the configured threshold. This ensures tickets are only closed when there’s been no reply activity for the set number of days.