### PR TITLE
fix: use correct config keys for Google OAuth client ID/secret

### DIFF
--- a/app/Http/Controllers/SocialLoginController.php
+++ b/app/Http/Controllers/SocialLoginController.php
@@ -32,8 +32,8 @@ class SocialLoginController extends Controller
         ]);
 
         $this->google_driver = Socialite::buildProvider(GoogleProvider::class, [
-            'client_id' => config('settings.google_client_id'),
-            'client_secret' => config('settings.google_client_secret'),
+            'client_id' => config('settings.oauth_google_client_id'),
+            'client_secret' => config('settings.oauth_google_client_secret'),
             'redirect' => '/oauth/google/callback',
         ]);
     }


### PR DESCRIPTION
Google OAuth was broken because it was using `google_client_id` and `google_client_secret` instead of the correct `oauth_google_client_id` and `oauth_google_client_secret` config keys.