### PR TITLE
feat: Add invoice reminder logic for services expiring in x days

### DIFF
--- a/app/Events/Invoice/Reminder.php
+++ b/app/Events/Invoice/Reminder.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Events\Invoice;
+
+use App\Models\Invoice;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class Reminder
+{
+    use Dispatchable, SerializesModels;
+
+    public Invoice $invoice;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(Invoice $invoice)
+    {
+        $this->invoice = $invoice;
+    }
+}

--- a/app/Listeners/SendMailListener.php
+++ b/app/Listeners/SendMailListener.php
@@ -4,6 +4,7 @@ namespace App\Listeners;
 
 use App\Events\Auth\Login;
 use App\Events\Invoice\Created as InvoiceCreated;
+use App\Events\Invoice\Reminder as InvoiceReminder;
 use App\Events\Order\Created as OrderCreated;
 use App\Events\User\Created as UserCreated;
 use App\Helpers\NotificationHelper;
@@ -14,7 +15,7 @@ class SendMailListener
     /**
      * Handle the event.
      */
-    public function handle(InvoiceCreated|OrderCreated|UserCreated|Login $event): void
+    public function handle(InvoiceCreated|InvoiceReminder|OrderCreated|UserCreated|Login $event): void
     {
 
         if ($event instanceof InvoiceCreated) {
@@ -34,6 +35,16 @@ class SendMailListener
                 'time' => now()->format('Y-m-d H:i:s'),
             ];
             NotificationHelper::loginDetectedNotification($user, $data);
+        } elseif ($event instanceof InvoiceReminder) {
+            NotificationHelper::sendEmailNotification(
+                'pending_invoice_reminder',
+                [
+                    'invoice' => $event->invoice,
+                    'items' => $event->invoice->items,
+                    'total' => $event->invoice->formattedTotal,
+                ],
+                $event->invoice->user
+            );
         }
     }
 }

--- a/database/seeders/EmailTemplateSeeder.php
+++ b/database/seeders/EmailTemplateSeeder.php
@@ -64,6 +64,34 @@ class EmailTemplateSeeder extends Seeder
                 HTML,
             ],
             [
+                'key' => 'pending_invoice_reminder',
+                'subject' => 'Reminder: Your Invoice is Pending Payment',
+                'body' => <<<'HTML'
+                # Your Invoice is Pending Payment
+
+                This is a reminder that your invoice is still pending payment.
+
+                Total amount: **{{ $total }}**
+
+                <div class="table">
+
+                |   Item   | Quantity |  Price   |
+                | :------: | :------: | :------: |
+                @foreach ($items as $item)
+                | {{ $item->description }} | {{ $item->quantity }} | {{ $item->price }} |
+                @endforeach
+                </div>
+
+                <div class="action">
+                    <a class="button button-blue" href="{{ route('invoices.show', $invoice) }}">
+                        View Invoice
+                    </a>
+                </div>
+
+                Please make the payment before the due date to avoid service interruptions.
+                HTML,
+            ],            
+            [
                 'key' => 'new_order_created',
                 'subject' => 'New order created',
                 'body' => <<<'HTML'


### PR DESCRIPTION
Previously, there was a setting in the admin panel for unpaid invoice reminders, but there was no actual implementation in the CronJob to trigger such reminders.

This PR adds the missing logic:
	•	Introduces a new email template for invoice reminders
	•	Adds the corresponding Invoice Reminder event and listener
	•	Updates the CronJob to check services that are still in active status and have associated invoices in pending status. If the service is set to expire in X days (based on admin settings), it triggers the InvoiceReminder event to send a reminder email to the user

This ensures users are properly notified about unpaid invoices before their services expire.