### PR TITLE
fix: Disable Convoy backups when set to 0, not unlimited

### DIFF
--- a/extensions/Servers/Convoy/Convoy.php
+++ b/extensions/Servers/Convoy/Convoy.php
@@ -265,7 +265,7 @@ class Convoy extends Server
                 'disk' => $disk * 1024 * 1024,
                 'snapshots' => (int) $snapshot,
                 'bandwidth' => (int) $bandwidth == 0 ? null : (int) $bandwidth * 1024 * 1024,
-                'backups' => (int) $backups == 0 ? null : (int) $backups,
+                'backups' => (int) $backups,
                 'address_ids' => $ips,
             ],
             'account_password' => $password,


### PR DESCRIPTION
I noticed that when the backups field is set to 0, it grants users an unlimited backup quota. This could lead to issues if we don’t intend to provide extra backups to users, as it might not align with our intended behavior.