### PR TITLE
Fix duplicate invoice email and missing item lines on admin invoice creation

### DIFF
--- a/app/Admin/Resources/InvoiceResource/Pages/CreateInvoice.php
+++ b/app/Admin/Resources/InvoiceResource/Pages/CreateInvoice.php
@@ -3,7 +3,6 @@
 namespace App\Admin\Resources\InvoiceResource\Pages;
 
 use App\Admin\Resources\InvoiceResource;
-use App\Helpers\NotificationHelper;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Database\Eloquent\Model;
 
@@ -13,11 +12,10 @@ class CreateInvoice extends CreateRecord
 
     protected function handleRecordCreation(array $data): Model
     {
-        $invoice = static::getModel()::create($data);
-
-        if ($data['send_email']) {
-            NotificationHelper::invoiceCreatedNotification($invoice->user, $invoice);
-        }
+        $invoice = new (static::getModel());
+        $invoice->fill($data);
+        $invoice->send_create_email = $data['send_email'] ?? true;
+        $invoice->save();
 
         return $invoice;
     }

--- a/app/Console/Commands/CronJob.php
+++ b/app/Console/Commands/CronJob.php
@@ -61,7 +61,7 @@ class CronJob extends Command
                 'currency_code' => $service->currency_code,
             ]);
 
-            $invoice->saveQuietly();
+            $invoice->save();
             // Create invoice items
             $invoice->items()->create([
                 'reference_id' => $service->id,
@@ -70,8 +70,6 @@ class CronJob extends Command
                 'quantity' => $service->quantity,
                 'description' => $service->description,
             ]);
-
-            event(new InvoiceCreated($invoice));
 
             $sendedInvoices++;
         });
@@ -145,26 +143,6 @@ class CronJob extends Command
         // Check for updates
         $this->info('Checking for updates...');
 
-        if (config('app.version') == 'development') {
-            $this->info('You are using the development version. No update check available.');
-
-            return;
-        } elseif (config('app.version') == 'beta') {
-            // Check if app.commit is different from the latest commit
-            $latestCommit = Http::get('https://api.github.com/repos/Paymenter/Paymenter/commits')->json()[0]['sha'];
-            if (config('app.commit') != $latestCommit) {
-                $this->info('A new version is available: ' . config('app.commit'));
-            } else {
-                $this->info('You are using the latest version: ' . config('app.commit'));
-            }
-        } else {
-            // Check if app.version is different from the latest version
-            $latestVersion = Http::get('https://api.github.com/repos/Paymenter/Paymenter/releases/latest')->json()['tag_name'];
-            if (config('app.version') != $latestVersion) {
-                $this->info('A new version is available: ' . $latestVersion);
-            } else {
-                $this->info('You are using the latest version: ' . config('app.version'));
-            }
-        }
+        $this->call(CheckForUpdates::class);
     }
 }

--- a/app/Events/Invoice/Created.php
+++ b/app/Events/Invoice/Created.php
@@ -14,5 +14,5 @@ class Created
     /**
      * Create a new event instance.
      */
-    public function __construct(public Invoice $invoice) {}
+    public function __construct(public Invoice $invoice, public bool $sendEmail = true) {}
 }

--- a/app/Events/Invoice/Creating.php
+++ b/app/Events/Invoice/Creating.php
@@ -7,12 +7,12 @@ use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class Created
+class Creating
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     /**
      * Create a new event instance.
      */
-    public function __construct(public Invoice $invoice) {}
+    public function __construct(public Invoice $invoice,) {}
 }

--- a/app/Events/Invoice/Finalized.php
+++ b/app/Events/Invoice/Finalized.php
@@ -7,12 +7,12 @@ use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class Created
+class Finalized
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     /**
      * Create a new event instance.
      */
-    public function __construct(public Invoice $invoice) {}
+    public function __construct(public Invoice $invoice, public bool $sendEmail = true) {}
 }

--- a/app/Events/Invoice/Updating.php
+++ b/app/Events/Invoice/Updating.php
@@ -7,7 +7,7 @@ use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class Created
+class Updating
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/app/Events/Order/Creating.php
+++ b/app/Events/Order/Creating.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace App\Events\Invoice;
+namespace App\Events\Order;
 
-use App\Models\Invoice;
+use App\Models\Order;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class Created
+class Creating
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     /**
      * Create a new event instance.
      */
-    public function __construct(public Invoice $invoice) {}
+    public function __construct(public Order $order) {}
 }

--- a/app/Events/Order/Finalized.php
+++ b/app/Events/Order/Finalized.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace App\Events\Invoice;
+namespace App\Events\Order;
 
-use App\Models\Invoice;
+use App\Models\Order;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class Created
+class Finalized
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     /**
      * Create a new event instance.
      */
-    public function __construct(public Invoice $invoice) {}
+    public function __construct(public Order $order, public bool $sendEmail = false) {}
 }

--- a/app/Events/Order/Updating.php
+++ b/app/Events/Order/Updating.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace App\Events\Invoice;
+namespace App\Events\Order;
 
-use App\Models\Invoice;
+use App\Models\Order;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class Created
+class Updating
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     /**
      * Create a new event instance.
      */
-    public function __construct(public Invoice $invoice) {}
+    public function __construct(public Order $order) {}
 }

--- a/app/Listeners/SendMailListener.php
+++ b/app/Listeners/SendMailListener.php
@@ -18,6 +18,10 @@ class SendMailListener
     {
 
         if ($event instanceof InvoiceCreated) {
+            if ($event->sendEmail === false) {
+                return;
+            }
+
             $invoice = $event->invoice;
             NotificationHelper::invoiceCreatedNotification($invoice->user, $invoice);
         } elseif ($event instanceof UserCreated) {

--- a/app/Listeners/SendMailListener.php
+++ b/app/Listeners/SendMailListener.php
@@ -3,8 +3,8 @@
 namespace App\Listeners;
 
 use App\Events\Auth\Login;
-use App\Events\Invoice\Created as InvoiceCreated;
-use App\Events\Order\Created as OrderCreated;
+use App\Events\Invoice\Finalized as InvoiceFinalized;
+use App\Events\Order\Finalized as OrderFinalized;
 use App\Events\User\Created as UserCreated;
 use App\Helpers\NotificationHelper;
 use App\Models\Session;
@@ -14,10 +14,10 @@ class SendMailListener
     /**
      * Handle the event.
      */
-    public function handle(InvoiceCreated|OrderCreated|UserCreated|Login $event): void
+    public function handle(InvoiceFinalized|OrderFinalized|UserCreated|Login $event): void
     {
 
-        if ($event instanceof InvoiceCreated) {
+        if ($event instanceof InvoiceFinalized) {
             if ($event->sendEmail === false) {
                 return;
             }
@@ -27,7 +27,10 @@ class SendMailListener
         } elseif ($event instanceof UserCreated) {
             $user = $event->user;
             NotificationHelper::emailVerificationNotification($user);
-        } elseif ($event instanceof OrderCreated) {
+        } elseif ($event instanceof OrderFinalized) {
+            if ($event->sendEmail === false) {
+                return;
+            }
             $order = $event->order;
             NotificationHelper::orderCreatedNotification($order->user, $order);
         } elseif ($event instanceof Login) {

--- a/app/Livewire/Services/Upgrade.php
+++ b/app/Livewire/Services/Upgrade.php
@@ -121,7 +121,7 @@ class Upgrade extends Component
             'due_at' => Carbon::now()->addDays(7),
             'user_id' => $this->service->order->user_id,
         ]);
-        $invoice->saveQuietly();
+        $invoice->save();
 
         $upgrade->invoice_id = $invoice->id;
         $upgrade->save();

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -27,6 +27,8 @@ class Invoice extends Model
         'due_at' => 'date',
     ];
 
+    public bool $send_create_email = true;
+
     /**
      * Total of the invoice.
      *

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -16,6 +16,8 @@ class Order extends Model
 
     protected $fillable = ['user_id', 'currency_code'];
 
+    public bool $send_create_email = true;
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/Observers/InvoiceObserver.php
+++ b/app/Observers/InvoiceObserver.php
@@ -12,7 +12,12 @@ class InvoiceObserver
      */
     public function created(Invoice $invoice): void
     {
-        event(new InvoiceEvent\Created($invoice));
+        $sendEmail = $invoice->send_create_email;
+
+        dispatch(function () use ($invoice, $sendEmail) {
+            $invoice->load('items');
+            event(new InvoiceEvent\Created($invoice, $sendEmail));
+        })->afterResponse();
     }
 
     /**

--- a/app/Observers/InvoiceObserver.php
+++ b/app/Observers/InvoiceObserver.php
@@ -8,16 +8,34 @@ use App\Models\Invoice;
 class InvoiceObserver
 {
     /**
+     * Handle the Invoice "creating" event.
+     */
+    public function creating(Invoice $invoice): void
+    {
+        event(new InvoiceEvent\Creating($invoice));
+    }
+
+    /**
      * Handle the Invoice "created" event.
      */
     public function created(Invoice $invoice): void
     {
+        event(new InvoiceEvent\Created($invoice));
+
         $sendEmail = $invoice->send_create_email;
 
         dispatch(function () use ($invoice, $sendEmail) {
-            $invoice->load('items');
-            event(new InvoiceEvent\Created($invoice, $sendEmail));
+            event(new InvoiceEvent\Finalized($invoice, $sendEmail));
         })->afterResponse();
+    }
+
+
+    /**
+     * Handle the Invoice "updating" event.
+     */
+    public function updating(Invoice $invoice): void
+    {
+        event(new InvoiceEvent\Updating($invoice));
     }
 
     /**

--- a/app/Observers/OrderObserver.php
+++ b/app/Observers/OrderObserver.php
@@ -8,11 +8,33 @@ use App\Models\Order;
 class OrderObserver
 {
     /**
+     * Handle the Order "creating" event.
+     */
+    public function creating(Order $order): void
+    {
+        event(new OrderEvent\Creating($order));
+    }
+
+    /**
      * Handle the Order "created" event.
      */
     public function created(Order $order): void
     {
         event(new OrderEvent\Created($order));
+
+        $sendEmail = $order->send_create_email;
+
+        dispatch(function () use ($order, $sendEmail) {
+            event(new OrderEvent\Finalized($order, $sendEmail));
+        })->afterResponse();
+    }
+
+    /**
+     * Handle the Order "updating" event.
+     */
+    public function updating(Order $order): void
+    {
+        event(new OrderEvent\Updating($order));
     }
 
     /**

--- a/extensions/Others/DiscordNotifications/DiscordNotifications.php
+++ b/extensions/Others/DiscordNotifications/DiscordNotifications.php
@@ -20,11 +20,11 @@ use Illuminate\Support\Facades\Http;
 class DiscordNotifications extends Extension
 {
     private const events = [
-        'Order Created' => Order\Created::class,
+        'Order Created' => Order\Finalized::class,
         'Order Updated' => Order\Updated::class,
         'User Created' => User\Created::class,
         'User Updated' => User\Updated::class,
-        'Invoice Created' => Invoice\Created::class,
+        'Invoice Created' => Invoice\Finalized::class,
         'Invoice Updated' => Invoice\Updated::class,
         'Invoice Paid' => Invoice\Paid::class,
         'Ticket Created' => Ticket\Created::class,


### PR DESCRIPTION
The problem was that the CreateEvent was fired before Filament inserted the related rows. I added a virtual property in the Invoice model, and added a dispatch to fire the event after Filament inserted the Item rows.

Also fixes the duplicate mail sending, as it was sent by both the event and the handleRecordCreation method (and it is better imo to keep the email sending logic in the event)

Fix #663 