### PR TITLE
feat: Company tax id and company id

### DIFF
--- a/app/Classes/Settings.php
+++ b/app/Classes/Settings.php
@@ -219,6 +219,16 @@ class Settings
                     'type' => 'select',
                     'options' => array_merge(['' => 'None'], config('app.countries')),
                 ],
+                [
+                    'name' => 'company_tax_id',
+                    'label' => 'Company Tax ID',
+                    'type' => 'text',
+                ],
+                [
+                    'name' => 'company_coc_id',
+                    'label' => 'Company Chamber of Commerce ID',
+                    'type' => 'text',
+                ],
             ],
             'tax' => [
                 [

--- a/app/Classes/Settings.php
+++ b/app/Classes/Settings.php
@@ -228,7 +228,6 @@ class Settings
                     'name' => 'company_id',
                     'label' => 'Company ID',
                     'type' => 'text',
-                    'description' => 'Can be a Chamber of Commerce number, or likewise.',
                 ],
             ],
             'tax' => [

--- a/app/Classes/Settings.php
+++ b/app/Classes/Settings.php
@@ -225,9 +225,10 @@ class Settings
                     'type' => 'text',
                 ],
                 [
-                    'name' => 'company_coc_id',
-                    'label' => 'Company Chamber of Commerce ID',
+                    'name' => 'company_id',
+                    'label' => 'Company ID',
                     'type' => 'text',
+                    'description' => 'Can be a Chamber of Commerce number, or likewise.',
                 ],
             ],
             'tax' => [

--- a/lang/en/invoices.php
+++ b/lang/en/invoices.php
@@ -16,9 +16,10 @@ return [
     'paid' => 'Paid',
     'payment_pending' => 'Payment Pending',
     'checking_payment' => 'Checking Payment',
-
     'invoice_date' => 'Invoice Date',
     'invoice_no' => 'Invoice No',
+    'tax_id' => 'Tax ID',
+    'coc_id' => 'COC ID',
     'item' => 'Item',
     'quantity' => 'Quantity',
     'transactions' => 'Transactions',

--- a/lang/en/invoices.php
+++ b/lang/en/invoices.php
@@ -19,7 +19,7 @@ return [
     'invoice_date' => 'Invoice Date',
     'invoice_no' => 'Invoice No',
     'tax_id' => 'Tax ID',
-    'coc_id' => 'COC ID',
+    'company_id' => 'Company ID',
     'item' => 'Item',
     'quantity' => 'Quantity',
     'transactions' => 'Transactions',

--- a/lang/nl/invoices.php
+++ b/lang/nl/invoices.php
@@ -19,7 +19,7 @@ return [
     'invoice_date' => 'Factuurdatum',
     'invoice_no' => 'Factuurnummer',
     'tax_id' => 'BTW nummer',
-    'coc_id' => 'KVK nummer',
+    'company_id' => 'KVK nummer',
     'item' => 'Artikel',
     'quantity' => 'Aantal',
     'transactions' => 'Transacties',

--- a/lang/nl/invoices.php
+++ b/lang/nl/invoices.php
@@ -16,9 +16,10 @@ return [
     'paid' => 'Betaald',
     'payment_pending' => 'Betaling in afwachting',
     'checking_payment' => 'Checking Payment',
-
     'invoice_date' => 'Factuurdatum',
     'invoice_no' => 'Factuurnummer',
+    'tax_id' => 'BTW nummer',
+    'coc_id' => 'KVK nummer',
     'item' => 'Artikel',
     'quantity' => 'Aantal',
     'transactions' => 'Transacties',

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -121,6 +121,22 @@
                 {{ config('settings.company_phone') }}
             </td>
         </tr>
+        <tr>
+            <td></td>
+            <td>
+                @if(config('settings.company_tax_id'))
+                    {{ __('invoices.tax_id') }}: {{ config('settings.company_tax_id') }}
+                @endif
+            </td>
+        </tr>
+        <tr>
+            <td></td>
+            <td>
+                @if(config('settings.company_coc_id'))
+                    {{ __('invoices.coc_id') }}: {{ config('settings.company_coc_id') }}
+                @endif
+            </td>
+        </tr>
     </table>
 
     <table style="margin-top: 40px;" class="invoice-items">

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -132,8 +132,8 @@
         <tr>
             <td></td>
             <td>
-                @if(config('settings.company_coc_id'))
-                    {{ __('invoices.coc_id') }}: {{ config('settings.company_coc_id') }}
+                @if(config('settings.company_id'))
+                    {{ __('invoices.company_id') }}: {{ config('settings.company_id') }}
                 @endif
             </td>
         </tr>


### PR DESCRIPTION
Adds settings for company tax id and company (chamber of commerce) id and show them on the invoice PDF as required by most countries.

![screenshot1](https://github.com/user-attachments/assets/418cd2a2-f43b-4ba4-9616-75d83ba03cda)
![screenshot2](https://github.com/user-attachments/assets/072720f4-4267-4ec5-9af4-c5551167766d)

