### PR TITLE
fix: update special-char requirement in Convoy password regex

### DIFF
--- a/extensions/Servers/Convoy/Convoy.php
+++ b/extensions/Servers/Convoy/Convoy.php
@@ -187,7 +187,7 @@ class Convoy extends Server
     private function createPassword()
     {
         $password = Str::password();
-        while (!preg_match('/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,50}$/', $password)) {
+        while (!preg_match('/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#\$%\^&\*]).{8,50}$/', $password)) {
             $password = Str::password();
         }
 


### PR DESCRIPTION
Fix intermittent VM creation failures by aligning the special‐character regex behavior with upstream Convoy.

https://github.com/ConvoyPanel/panel/blob/develop/resources/scripts/util/validation.ts#L26-L34