### PR TITLE
Fix: Wrong name in stripe ext. Placeholder

### DIFF
--- a/extensions/Gateways/Stripe/Stripe.php
+++ b/extensions/Gateways/Stripe/Stripe.php
@@ -39,7 +39,7 @@ class Stripe extends Gateway
             [
                 'name' => 'stripe_secret_key',
                 'label' => 'Stripe Restricted key',
-                'placeholder' => 'Enter your Stripe Publishable API key',
+                'placeholder' => 'Enter your Stripe Restricted API key',
                 'type' => 'text',
                 'description' => 'Find your API keys at https://dashboard.stripe.com/apikeys',
                 'required' => true,


### PR DESCRIPTION
Placeholder is labeled wrong. Showed by @NorteX-dev on discord 

Discord Message ID: 1366384843230810242
![image](https://github.com/user-attachments/assets/0755e46f-54ef-4229-afce-074a3ede9660)
