### PR TITLE
Update Pterodactyl.php

### DIFF
--- a/extensions/Servers/Pterodactyl/Pterodactyl.php
+++ b/extensions/Servers/Pterodactyl/Pterodactyl.php
@@ -268,7 +268,7 @@ class Pterodactyl extends Server
         if (!$user) {
             $user = $this->request('/api/application/users', 'post', [
                 'email' => $orderUser->email,
-                'username' => (preg_replace('/[^a-zA-Z0-9]/', '', strtolower($orderUser->name)) ?? Str::random(8)) . '_' . Str::random(4),
+			    'username' => explode('@', $orderUser->email)[0],
                 'first_name' => $orderUser->first_name ?? '',
                 'last_name' => $orderUser->last_name ?? '',
             ])['attributes']['id'];


### PR DESCRIPTION
I delved into the code process, and realized that this was done absolutely contradictoryly all the rules and norms of the code. This is the simplest and work option that will completely remove the error when creating a user, regardless of the user registration language. In FIRST and LAST NAME! The mail all will be true in the name of the login and it will be possible not to be exhausted above the code!