### PR TITLE
Add RTL Tag if Lang is Set to Arabic

### DIFF
--- a/themes/default/views/components/navigation/sidebar.blade.php
+++ b/themes/default/views/components/navigation/sidebar.blade.php
@@ -1,3 +1,3 @@
-<aside class="mt-14 w-64 h-screen md:flex hidden flex-col justify-between border-e border-neutral bg-background-secondary fixed top-0 left-0 z-10">
+<aside class="mt-14 w-64 h-screen md:flex hidden flex-col justify-between border-e border-neutral bg-background-secondary top-0 left-0 z-10">
     <x-navigation.sidebar-links />
 </aside>

--- a/themes/default/views/layouts/app.blade.php
+++ b/themes/default/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" @if(app()->getLocale() === 'ar') dir="rtl" @endif>
 
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
This makes the direction of the pages turn to the right direction, if the language is set to Arabic. I've thought about adding more checks for other RTL languages, but since there's no one to actually test them it wouldn't be good.

I've tested the changes and dug around for bugs. I fixed the sidebar in the dashboard, which gets stuck to the left instead of actually going right due to the `fixed` tag, which I've removed, and there seems to be no reason/difference for it after checking and reading for a bit.