### PR TITLE
Use Mpdf instead of DomPDF for Better Language Support

### DIFF
--- a/app/Classes/PDF.php
+++ b/app/Classes/PDF.php
@@ -3,13 +3,13 @@
 namespace App\Classes;
 
 use App\Models\Invoice;
-use Barryvdh\DomPDF\Facade\Pdf as DomPDF;
+use Mccarlosen\LaravelMpdf\Facades\LaravelMpdf as Mpdf;
 
 class PDF
 {
     public static function generateInvoice(Invoice $invoice)
     {
-        $pdf = DomPDF::loadView('pdf.invoice', ['invoice' => $invoice]);
+        $pdf = Mpdf::loadView('pdf.invoice', ['invoice' => $invoice]);
 
         return $pdf;
     }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-pdo_mysql": "*",
         "ext-zip": "*",
         "andreiio/blade-remix-icon": "^3.6.0",
-        "barryvdh/laravel-dompdf": "^3.0",
+        "carlos-meneses/laravel-mpdf": "^2.1",
         "endroid/qr-code": "^5.0",
         "filament/filament": "^3.2",
         "flowframe/laravel-trend": "^0.4.0",
@@ -30,6 +30,7 @@
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.13",
+        "carlos-meneses/laravel-mpdf": "^2.1",
         "fakerphp/faker": "^1.23",
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.13",

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -1,4 +1,4 @@
-<html lang="en">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" @if(in_array(app()->getLocale(), config('app.rtl_locales'))) dir="rtl" @endif>'
 
 <head>
     <meta charset="UTF-8">

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -27,7 +27,7 @@
         }
 
         table th {
-            text-align: left;
+            text-align: start;
             color: #999;
             border-bottom: 2px solid #ddd;
             padding: 10px 0 15px 0;

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -27,7 +27,7 @@
         }
 
         table th {
-            text-align: start;
+            text-align: justify;
             color: #999;
             border-bottom: 2px solid #ddd;
             padding: 10px 0 15px 0;

--- a/themes/default/views/invoices/show.blade.php
+++ b/themes/default/views/invoices/show.blade.php
@@ -91,17 +91,17 @@
                 <thead class="bg-background border border-neutral rounded-lg">
                     <tr>
                         <th scope="col"
-                            class="p-4 text-xs font-semibold tracking-wider text-left uppercase rounded-l-lg">
+                            class="p-4 text-xs font-semibold tracking-wider text-justify uppercase rounded-l-lg">
                             {{ __('invoices.item') }}
                         </th>
-                        <th scope="col" class="p-4 text-xs font-semibold tracking-wider text-left uppercase">
+                        <th scope="col" class="p-4 text-xs font-semibold tracking-wider text-justify uppercase">
                             {{ __('invoices.price') }}
                         </th>
-                        <th scope="col" class="p-4 text-xs font-semibold tracking-wider text-left uppercase">
+                        <th scope="col" class="p-4 text-xs font-semibold tracking-wider text-justify uppercase">
                             {{ __('invoices.quantity') }}
                         </th>
                         <th scope="col"
-                            class="p-4 text-xs font-semibold tracking-wider text-left uppercase rounded-r-lg">
+                            class="p-4 text-xs font-semibold tracking-wider text-justify uppercase rounded-r-lg">
                             {{ __('invoices.total') }}
                         </th>
                     </tr>
@@ -152,17 +152,17 @@
                         <thead class="bg-background border border-neutral rounded-lg">
                             <tr>
                                 <th scope="col"
-                                    class="p-4 text-xs font-semibold tracking-wider text-left uppercase rounded-l-lg">
+                                    class="p-4 text-xs font-semibold tracking-wider text-justify uppercase rounded-l-lg">
                                     {{ __('invoices.date') }}
                                 </th>
-                                <th scope="col" class="p-4 text-xs font-semibold tracking-wider text-left uppercase">
+                                <th scope="col" class="p-4 text-xs font-semibold tracking-wider text-justify uppercase">
                                     {{ __('invoices.transaction_id') }}
                                 </th>
-                                <th scope="col" class="p-4 text-xs font-semibold tracking-wider text-left uppercase">
+                                <th scope="col" class="p-4 text-xs font-semibold tracking-wider text-justify uppercase">
                                     {{ __('invoices.gateway') }}
                                 </th>
                                 <th scope="col"
-                                    class="p-4 text-xs font-semibold tracking-wider text-left uppercase rounded-r-lg">
+                                    class="p-4 text-xs font-semibold tracking-wider text-justify uppercase rounded-r-lg">
                                     {{ __('invoices.amount') }}
                                 </th>
                             </tr>


### PR DESCRIPTION
Mpdf seems to be a lot better in terms of different languages support, with good defaults for fonts and such. 
DomPDF puts `?` for every foreign char, which makes the billing panel critically unusable in regions that use languages whose chars are special/unique.

I've also went ahead and added support for adaptive RTL document direction depending on the currently set language by the user, this is also great if the user wants the invoice in a different language. Also fixed column headers direction both in the rendered invoice pdf & the dashboard's invoices page, it will also change depending direction status.

A couple of notes
this may need further testing as a it's a core change, and also updating needs testing, not sure if it will break if composer doesn't install the laravel mpdf lib in the new composer.json when a user updates.

Also, there are no translations for the "Paid" text (in the invoice pdf, in front of status), or the "Download PDF" button which would be great to have translated strings for.

One last thing, I've done a cleaner job here than previously mentioned in the discord support thread, I wasn't using a laravel mpdf lib and I think it would've much more manual work.