### PR TITLE
Docker-Compose Changes

### DIFF
--- a/docker-compose.beta.yml
+++ b/docker-compose.beta.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 x-common:
   database:
     &db-environment
@@ -16,7 +15,7 @@ x-common:
 #
 services:
   database:
-    image: mariadb:10.11
+    image: mariadb:lts
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     volumes:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 x-common:
   database:
     &db-environment
@@ -16,7 +15,7 @@ x-common:
 #
 services:
   database:
-    image: mariadb:10.11
+    image: mariadb:lts
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     volumes:


### PR DESCRIPTION
Hello! A little update to the docker-compose files. 

- version: '3.8' is obsolete we can see this here: https://docs.docker.com/reference/compose-file/version-and-name/

I have updated the MariaDB image to use the lts tag. This tag refers to the long-term support version, which is stable and includes the latest security patches. It works reliably in my environment, and I recommend we use it to ensure better maintainability and up-to-date support.

If you have any questions please write me! Thank you.