### PR TITLE
feat(admin): add test email functionality to mail settings

### DIFF
--- a/app/Mail/TestMail.php
+++ b/app/Mail/TestMail.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+
+class TestMail extends Mailable
+{
+    use Queueable;
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Test Email from ' . config('app.name'),
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            htmlString: sprintf(
+                '<h1>Test Email</h1><p>This is a test email from %s</p><p>Time: %s</p>',
+                e(config('app.name')),
+                e(now()->toDateTimeString())
+            ),
+        );
+    }
+}


### PR DESCRIPTION
partly adds #766 

There are a couple of Thoughts i still have that may need changes:
1. I created a new Testmail, which you might not want. I could also just make a new Email Template and in that case use the default mail. *or use a already existing template but that would be kinda weird
2. when pressing the send test mail button it silently saves the form again. Idk if i should revert the changes so it always runs normal (with the notification of the saving)

tested out and works perfectly fine