### PR TITLE
fix: hide register btn on mobile when disabled

### DIFF
--- a/themes/default/views/components/navigation/index.blade.php
+++ b/themes/default/views/components/navigation/index.blade.php
@@ -224,11 +224,13 @@
 
                             @else
                             <div class="flex flex-col gap-3 mb-3">
+                                @if(!config('settings.registration_disabled', false))
                                 <a href="{{ route('register') }}" wire:navigate>
                                     <x-button.primary>
                                         {{ __('navigation.register') }}
                                     </x-button.primary>
                                 </a>
+                                @endif
                                 <a href="{{ route('login') }}" wire:navigate>
                                     <x-button.secondary>
                                         {{ __('navigation.login') }}


### PR DESCRIPTION
prevents sidebar in the admin area from scrolling to top after clicking sidebar links for better UX

before: https://github.com/user-attachments/assets/97932641-37a9-48ff-b80b-b40e75651d6f
after: https://github.com/user-attachments/assets/67fae27f-6877-4acf-8e14-4df3ecc8dfba


