### PR TITLE
fix: couple of bugs when payment gateway implements canUseGateway()

### DIFF
--- a/app/Helpers/ExtensionHelper.php
+++ b/app/Helpers/ExtensionHelper.php
@@ -292,7 +292,7 @@ class ExtensionHelper
 
         foreach (Gateway::all() as $gateway) {
             if (self::hasFunction($gateway, 'canUseGateway')) {
-                if (self::getExtension('gateway', $gateway, $gateway->settings)->canUseGateway($items, $type)) {
+                if (self::getExtension('gateway',  $gateway->extension, $gateway->settings)->canUseGateway($items, $type)) {
                     $gateways[] = $gateway;
                 }
             } else {

--- a/app/Livewire/Invoices/Show.php
+++ b/app/Livewire/Invoices/Show.php
@@ -37,7 +37,7 @@ class Show extends Component
         }
 
         if ($this->invoice->status === 'pending') {
-            $this->gateways = ExtensionHelper::getCheckoutGateways($this->invoice->products, 'invoice');
+            $this->gateways = ExtensionHelper::getCheckoutGateways($this->invoice->items, 'invoice');
             if (count($this->gateways) > 0 && !array_search($this->gateway, array_column($this->gateways, 'id')) !== false) {
                 $this->gateway = $this->gateways[0]->id;
             }


### PR DESCRIPTION
I tried implementing the canUseGateway($items, $type)-hook, but got some errors. These are my easy fixes which worked well for me, as I thought they must be typos.

The first error I got by just hooking up a (meaningless/empty) canUseGateway(), which I traced back to a typo in getCheckoutGateways().
The second error came when I recieved NULL as $items in invoices. Based on the [documentation](https://paymenter.org/development/extensions/gateway#canusegateway) I guess it should be the list of InvoiceItem.

Keep in mind I'm not a seasoned PHP-developer, and this is my first try at a pull request.