### PR TITLE
Add Scramble extensions that improve API documentation

### DIFF
--- a/app/Helpers/ApiDocumentation/AllowedIncludesExtension.php
+++ b/app/Helpers/ApiDocumentation/AllowedIncludesExtension.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Helpers\ApiDocumentation;
+
+use App\Http\Controllers\Api\ApiController;
+use Dedoc\Scramble\Infer\Extensions\Event\MethodCallEvent;
+use Dedoc\Scramble\Infer\Extensions\MethodReturnTypeExtension;
+use Dedoc\Scramble\Support\Type\ObjectType;
+use Dedoc\Scramble\Support\Type\Type;
+
+class AllowedIncludesExtension implements MethodReturnTypeExtension
+{
+    public function shouldHandle(ObjectType $type): bool
+    {
+        return $type->isInstanceOf(ApiController::class);
+    }
+
+    public function getMethodReturnType(MethodCallEvent $event): ?Type
+    {
+        if ($event->name === 'allowedIncludes') {
+            return $event->getArg('includes', 0);
+        }
+
+        return null;
+    }
+}

--- a/app/Helpers/ApiDocumentation/RequestUserExtension.php
+++ b/app/Helpers/ApiDocumentation/RequestUserExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Helpers\ApiDocumentation;
+
+use App\Models\User;
+use Dedoc\Scramble\Infer\Extensions\Event\MethodCallEvent;
+use Dedoc\Scramble\Infer\Extensions\MethodReturnTypeExtension;
+use Dedoc\Scramble\Support\Type\ObjectType;
+use Dedoc\Scramble\Support\Type\Type;
+use Illuminate\Http\Request;
+
+class RequestUserExtension implements MethodReturnTypeExtension
+{
+    public function shouldHandle(ObjectType $type): bool
+    {
+        return $type->isInstanceOf(Request::class);
+    }
+
+    public function getMethodReturnType(MethodCallEvent $event): ?Type
+    {
+        if ($event->name === 'user') {
+            return new ObjectType(User::class);
+        }
+
+        return null;
+    }
+}

--- a/app/Http/Controllers/Api/Admin/UserController.php
+++ b/app/Http/Controllers/Api/Admin/UserController.php
@@ -15,7 +15,7 @@ use Dedoc\Scramble\Attributes\QueryParameter;
 
 class UserController extends ApiController
 {
-    protected array $includes = [
+    protected const INCLUDES = [
         'properties',
         'orders',
         'services',
@@ -34,7 +34,7 @@ class UserController extends ApiController
         // Fetch users with pagination
         $users = QueryBuilder::for(User::class)
             ->allowedFilters(['first_name', 'last_name', 'email'])
-            ->allowedIncludes($this->allowedIncludes($this->includes))
+            ->allowedIncludes($this->allowedIncludes(self::INCLUDES))
             ->allowedSorts(['id', 'first_name', 'last_name', 'email', 'created_at'])
             ->simplePaginate(request('per_page', 15));
 
@@ -48,7 +48,7 @@ class UserController extends ApiController
     public function show(GetUserRequest $request, User $user)
     {
         $user = QueryBuilder::for(User::class)
-            ->allowedIncludes($this->allowedIncludes($this->includes))
+            ->allowedIncludes($this->allowedIncludes(self::INCLUDES))
             ->findOrFail($user->id);
 
         // Return the user as a JSON response

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Models\Traits\HasProperties;
 use App\Observers\UserObserver;
+use Dedoc\Scramble\Attributes\SchemaName;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasAvatar;
 use Filament\Panel;
@@ -16,6 +17,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Passport\HasApiTokens;
 
+#[SchemaName('UserModel')]
 #[ObservedBy([UserObserver::class])]
 class User extends Authenticatable implements FilamentUser, HasAvatar
 {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.13",
-        "dedoc/scramble": "^0.12.19",
+        "dedoc/scramble": "^0.12.21",
         "fakerphp/faker": "^1.23",
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.13",
@@ -51,7 +51,7 @@
             "Paymenter\\Extensions\\": "extensions/"
         }
     },
-    "autoload-dev": {   
+    "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d9290d926f6188fbc91a35f4317afc3",
+    "content-hash": "4acf40544f69df3c42adea467b86602f",
     "packages": [
         {
             "name": "andreiio/blade-remix-icon",
@@ -9640,16 +9640,16 @@
         },
         {
             "name": "dedoc/scramble",
-            "version": "v0.12.20",
+            "version": "v0.12.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dedoc/scramble.git",
-                "reference": "283bc6a8790ffaa5ea14d2cbdba83a42b414f7f5"
+                "reference": "5b2d7d5456942e2a7c984c6d7e4690ba66c05f16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dedoc/scramble/zipball/283bc6a8790ffaa5ea14d2cbdba83a42b414f7f5",
-                "reference": "283bc6a8790ffaa5ea14d2cbdba83a42b414f7f5",
+                "url": "https://api.github.com/repos/dedoc/scramble/zipball/5b2d7d5456942e2a7c984c6d7e4690ba66c05f16",
+                "reference": "5b2d7d5456942e2a7c984c6d7e4690ba66c05f16",
                 "shasum": ""
             },
             "require": {
@@ -9708,7 +9708,7 @@
             ],
             "support": {
                 "issues": "https://github.com/dedoc/scramble/issues",
-                "source": "https://github.com/dedoc/scramble/tree/v0.12.20"
+                "source": "https://github.com/dedoc/scramble/tree/v0.12.21"
             },
             "funding": [
                 {
@@ -9716,7 +9716,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-28T13:13:29+00:00"
+            "time": "2025-05-31T06:35:24+00:00"
         },
         {
             "name": "fakerphp/faker",
@@ -12638,6 +12638,6 @@
         "ext-pdo_mysql": "*",
         "ext-zip": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/config/scramble.php
+++ b/config/scramble.php
@@ -1,0 +1,114 @@
+<?php
+
+use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
+
+return [
+    /*
+     * Your API path. By default, all routes starting with this path will be added to the docs.
+     * If you need to change this behavior, you can add your custom routes resolver using `Scramble::routes()`.
+     */
+    'api_path' => 'api',
+
+    /*
+     * Your API domain. By default, app domain is used. This is also a part of the default API routes
+     * matcher, so when implementing your own, make sure you use this config if needed.
+     */
+    'api_domain' => null,
+
+    /*
+     * The path where your OpenAPI specification will be exported.
+     */
+    'export_path' => 'api.json',
+
+    'info' => [
+        /*
+         * API version.
+         */
+        'version' => env('API_VERSION', '0.0.1'),
+
+        /*
+         * Description rendered on the home page of the API documentation (`/docs/api`).
+         */
+        'description' => '',
+    ],
+
+    /*
+     * Customize Stoplight Elements UI
+     */
+    'ui' => [
+        /*
+         * Define the title of the documentation's website. App name is used when this config is `null`.
+         */
+        'title' => null,
+
+        /*
+         * Define the theme of the documentation. Available options are `light` and `dark`.
+         */
+        'theme' => 'light',
+
+        /*
+         * Hide the `Try It` feature. Enabled by default.
+         */
+        'hide_try_it' => false,
+
+        /*
+         * Hide the schemas in the Table of Contents. Enabled by default.
+         */
+        'hide_schemas' => false,
+
+        /*
+         * URL to an image that displays as a small square logo next to the title, above the table of contents.
+         */
+        'logo' => '',
+
+        /*
+         * Use to fetch the credential policy for the Try It feature. Options are: omit, include (default), and same-origin
+         */
+        'try_it_credentials_policy' => 'include',
+
+        /*
+         * There are three layouts for Elements:
+         * - sidebar - (Elements default) Three-column design with a sidebar that can be resized.
+         * - responsive - Like sidebar, except at small screen sizes it collapses the sidebar into a drawer that can be toggled open.
+         * - stacked - Everything in a single column, making integrations with existing websites that have their own sidebar or other columns already.
+         */
+        'layout' => 'responsive',
+    ],
+
+    /*
+     * The list of servers of the API. By default, when `null`, server URL will be created from
+     * `scramble.api_path` and `scramble.api_domain` config variables. When providing an array, you
+     * will need to specify the local server URL manually (if needed).
+     *
+     * Example of non-default config (final URLs are generated using Laravel `url` helper):
+     *
+     * ```php
+     * 'servers' => [
+     *     'Live' => 'api',
+     *     'Prod' => 'https://scramble.dedoc.co/api',
+     * ],
+     * ```
+     */
+    'servers' => null,
+
+    /**
+     * Determines how Scramble stores the descriptions of enum cases.
+     * Available options:
+     * - 'description' – Case descriptions are stored as the enum schema's description using table formatting.
+     * - 'extension' – Case descriptions are stored in the `x-enumDescriptions` enum schema extension.
+     *
+     *    @see https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-enum-descriptions
+     * - false - Case descriptions are ignored.
+     */
+    'enum_cases_description_strategy' => 'description',
+
+    'middleware' => [
+        'web',
+        RestrictedDocsAccess::class,
+    ],
+
+    'extensions' => [
+        \App\Helpers\ApiDocumentation\RequestUserExtension::class,
+        \App\Helpers\ApiDocumentation\AllowedIncludesExtension::class,
+    ],
+];


### PR DESCRIPTION
These are the initial set of changes for API documentation improvements. 

Basically these are 2 extensions that add the support of return type inference for `Request@user` and `ApiController@allowedIncludes` methods and register these extensions in the published `config/scramble.php` file.

I was not really sure where to place the extensions so I've placed them in `app/Helpers/ApiDocumentation `. Usually I place them in `app/Support/ApiDocumentation` folder, but I didn't want to introduce new folders in `app`.

Let me know if this looks fine to you, I'll be happy to contribute more things for API docs generation! 