### PR TITLE
fix: disallow credit payment usage if invoice already includes deposit credit

### DIFF
--- a/app/Livewire/Invoices/Show.php
+++ b/app/Livewire/Invoices/Show.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Invoices;
 use App\Classes\PDF;
 use App\Helpers\ExtensionHelper;
 use App\Livewire\Component;
+use App\Models\Credit;
 use App\Models\Gateway;
 use App\Models\Invoice;
 use Illuminate\Support\Facades\Auth;
@@ -51,6 +52,10 @@ class Show extends Component
 
         // We don't want to toggle use_credits before $this->pay() is called, otherwise it will always paid with credits
         $this->use_credits = true;
+        $hasCredits = $this->invoice->items()->where('reference_type', Credit::class)->exists();
+        if($hasCredits) {
+            $this->use_credits = false;
+        }
     }
 
     public function pay()

--- a/themes/default/views/invoices/show.blade.php
+++ b/themes/default/views/invoices/show.blade.php
@@ -68,7 +68,14 @@
                             </div>
                         @endif
                     </div>
-                    @if(Auth::user()->credits()->where('currency_code', $invoice->currency_code)->exists() && Auth::user()->credits()->where('currency_code', $invoice->currency_code)->first()->amount > 0)
+                    @php
+                        $credit = Auth::user()->credits()
+                                ->where('currency_code', $invoice->currency_code)
+                                ->where('amount', '>', 0)
+                                ->first();
+                        $itemHasCredit = $invoice->items()->where('reference_type', App\Models\Credit::class)->exists();
+                    @endphp
+                    @if($credit && !$itemHasCredit)
                         <x-form.checkbox wire:model="use_credits" name="use_credits" :label="__('product.use_credits')" />
                     @endif
                     @if(count($gateways) > 1)


### PR DESCRIPTION
This PR fixes a logic bug that allowed users to pay an invoice with credits **even when the invoice already contains a credit-based item (e.g., deposit)**
Now, the credit payment option (checkbox) will only show if:
- The user has available credits with the same currency_code as the invoice
- The invoice does NOT already include a credit item (`reference_type = Credit::class`) 