### PR TITLE
fix: add closeCancel method and update button action in Show component

### DIFF
--- a/app/Livewire/Services/Show.php
+++ b/app/Livewire/Services/Show.php
@@ -61,6 +61,11 @@ class Show extends Component
         }
     }
 
+    public function closeCancel()
+    {
+        $this->showCancel = false;
+    }
+
     public function goto($function)
     {
         // Check if function is allowed

--- a/themes/default/views/services/show.blade.php
+++ b/themes/default/views/services/show.blade.php
@@ -59,7 +59,7 @@
                             <livewire:services.cancel :service="$service" />
                             <x-slot name="closeTrigger">
                                 <div class="flex gap-4">
-                                    <button wire:confirm="Are you sure?" wire:click="openModal('')" @click="open = false"
+                                    <button wire:confirm="Are you sure?" wire:click="closeCancel"
                                         class="text-primary-100">
                                         <x-ri-close-fill class="size-6" />
                                     </button>


### PR DESCRIPTION
fixed error `Unable to call component method. Public method [openModal] not found on component` when closing cancel modal