### PR TITLE
fix(ext): overwrite config option data for "location"

### DIFF
--- a/extensions/Servers/Pterodactyl/Pterodactyl.php
+++ b/extensions/Servers/Pterodactyl/Pterodactyl.php
@@ -311,7 +311,9 @@ class Pterodactyl extends Server
         ];
         if ($deploymentData['auto_deploy']) {
             $serverCreationData['deploy'] = [
-                'locations' => $settings['location_ids'] ?? [],
+                'locations' => isset($settings['location']) 
+                    ? [$settings['location']] 
+                    : (array) $settings['location_ids'],
                 'dedicated_ip' => $settings['dedicated_ip'] ?? false,
                 'port_range' => $settings['port_range'] ?? [],
             ];


### PR DESCRIPTION
the environment variable for location didn't match the docs. this fixes the "location" config option to work as expected, along with "location_ids" to work by converting it into an array.