### PR TITLE
Refactor SocialLoginController to support dynamic OAuth providers and user auto-creation

### DIFF
--- a/app/Http/Controllers/SocialLoginController.php
+++ b/app/Http/Controllers/SocialLoginController.php
@@ -3,7 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\GithubProvider;
 use Laravel\Socialite\Two\GoogleProvider;
@@ -11,88 +15,158 @@ use SocialiteProviders\Discord\Provider as DiscordProvider;
 
 class SocialLoginController extends Controller
 {
-    protected $discord_driver;
+    protected array $providers = [
+        'discord' => [
+            'driver' => DiscordProvider::class,
+            'scopes' => ['email'],
+            'redirect' => '/oauth/discord/callback'
+        ],
+        'github' => [
+            'driver' => GithubProvider::class,
+            'scopes' => ['user:email'],
+            'redirect' => '/oauth/github/callback'
+        ],
+        'google' => [
+            'driver' => GoogleProvider::class,
+            'scopes' => ['email'],
+            'redirect' => '/oauth/google/callback'
+        ]
+    ];
 
-    protected $github_driver;
-
-    protected $google_driver;
-
-    public function __construct()
+    public function redirect(string $provider): RedirectResponse
     {
-        $this->discord_driver = Socialite::buildProvider(DiscordProvider::class, [
-            'client_id' => config('settings.oauth_discord_client_id'),
-            'client_secret' => config('settings.oauth_discord_client_secret'),
-            'redirect' => '/oauth/discord/callback',
-        ]);
+        if (!$this->isProviderEnabled($provider)) {
+            abort(404, 'Provider not available');
+        }
 
-        $this->github_driver = Socialite::buildProvider(GithubProvider::class, [
-            'client_id' => config('settings.oauth_github_client_id'),
-            'client_secret' => config('settings.oauth_github_client_secret'),
-            'redirect' => '/oauth/github/callback',
-        ]);
+        $driver = $this->getDriver($provider);
+        $scopes = $this->providers[$provider]['scopes'];
 
-        $this->google_driver = Socialite::buildProvider(GoogleProvider::class, [
-            'client_id' => config('settings.oauth_google_client_id'),
-            'client_secret' => config('settings.oauth_google_client_secret'),
-            'redirect' => '/oauth/google/callback',
+        return $driver->scopes($scopes)->redirect();
+    }
+
+    public function handle(string $provider): RedirectResponse
+    {
+        if (!$this->isProviderEnabled($provider)) {
+            abort(404, 'Provider not available');
+        }
+
+        try {
+            $oauthUser = $this->getDriver($provider)->user();
+
+            // Provider-specific validation
+            if (!$this->validateOAuthUser($provider, $oauthUser)) {
+                return redirect()->route('login')
+                    ->with('error', __('auth.oauth.invalid_account'));
+            }
+
+            DB::beginTransaction();
+
+            $user = $this->findOrCreateUser($provider, $oauthUser);
+            $this->updateUserProperties($user, $provider, $oauthUser);
+
+            DB::commit();
+
+            Auth::login($user, true);
+
+            return redirect()->route('home');
+        } catch (\Exception $e) {
+            DB::rollBack();
+            Log::error("OAuth login failed for provider {$provider}: " . $e->getMessage());
+
+            return redirect()->route('login')
+                ->with('error', __('auth.oauth.login_failed'));
+        }
+    }
+
+    protected function isProviderEnabled(string $provider): bool
+    {
+        return array_key_exists($provider, $this->providers) &&
+            config("settings.oauth_{$provider}");
+    }
+
+    protected function getDriver(string $provider)
+    {
+        $config = $this->providers[$provider];
+
+        return Socialite::buildProvider($config['driver'], [
+            'client_id' => config("settings.oauth_{$provider}_client_id"),
+            'client_secret' => config("settings.oauth_{$provider}_client_secret"),
+            'redirect' => $config['redirect'],
         ]);
     }
 
-    public function redirect($provider)
+    protected function validateOAuthUser(string $provider, $oauthUser): bool
     {
-        if (!config("settings.oauth_$provider")) {
-            abort(404);
+        // Check if email exists
+        if (empty($oauthUser->email)) {
+            return false;
         }
 
+        // Discord-specific validation
+        if ($provider === 'discord') {
+            return isset($oauthUser->user['verified']) &&
+                $oauthUser->user['verified'] === true;
+        }
+
+        return true;
+    }
+
+    protected function findOrCreateUser(string $provider, $oauthUser): User
+    {
+        $user = User::where('email', $oauthUser->email)->first();
+
+        if ($user) {
+            return $user;
+        }
+
+        $userData = $this->getUserDataFromOAuth($provider, $oauthUser);
+
+        $user = User::create([
+            'first_name' => $userData['first_name'],
+            'last_name' => $userData['last_name'],
+            'email' => $oauthUser->email,
+            'email_verified_at' => now(),
+            'password' => bcrypt(Str::random(32))
+        ]);
+
+        if (!$user) {
+            throw new \Exception('Failed to create user account');
+        }
+
+        return $user;
+    }
+
+    protected function getUserDataFromOAuth(string $provider, $oauthUser): array
+    {
         return match ($provider) {
-            'discord' => $this->discord_driver->scopes(['email'])->redirect(),
-            'github' => $this->github_driver->scopes(['user:email'])->redirect(),
-            'google' => $this->google_driver->scopes(['email'])->redirect(),
-            default => abort(404)
+            'discord' => [
+                'first_name' => $oauthUser->name ?? null,
+                'last_name' => $oauthUser->nickname ?? null,
+            ],
+            'google' => [
+                'first_name' => $oauthUser->user['given_name'] ?? $oauthUser->name ?? null,
+                'last_name' => $oauthUser->user['family_name'] ?? null,
+            ],
+            'github' => [
+                'first_name' => $oauthUser->nickname ?? $oauthUser->name ?? null,
+                'last_name' => $oauthUser->nickname ?? $oauthUser->name ?? null,
+            ],
+            default => [
+                'first_name' => $oauthUser->name ?? null,
+                'last_name' => $oauthUser->name,
+            ]
         };
     }
 
-    public function handle($provider)
+    protected function updateUserProperties(User $user, string $provider, $oauthUser): void
     {
-        if ($provider == 'discord') {
-            $oauth_user = $this->discord_driver->user();
-
-            if ($oauth_user->user['verified'] == false) {
-                return redirect()->route('login')->with('error', __('auth.oauth.unverified_discord_account'));
-            }
-
-            $user = User::where('email', $oauth_user->email)->first();
-            if (!$user) {
-                return redirect()->route('register')->with('error', __('auth.oauth.account_not_registered'));
-            }
-
-            Auth::login($user, true);
-
-            return redirect()->route('home');
-        } elseif ($provider == 'google') {
-            $oauth_user = $this->google_driver->user();
-
-            $user = User::where('email', $oauth_user->email)->first();
-            if (!$user) {
-                return redirect()->route('register')->with('error', __('auth.oauth.account_not_registered'));
-            }
-
-            Auth::login($user, true);
-
-            return redirect()->route('home');
-        } elseif ($provider == 'github') {
-            $oauth_user = $this->github_driver->user();
-
-            $user = User::where('email', $oauth_user->email)->first();
-            if (!$user) {
-                return redirect()->route('register')->with('error', __('auth.oauth.account_not_registered'));
-            }
-
-            Auth::login($user, true);
-
-            return redirect()->route('home');
-        } else {
-            return redirect()->route('login');
-        }
+        $user->properties()->updateOrCreate(
+            ['key' => "{$provider}_id"],
+            [
+                'value' => $oauthUser->id,
+                'name' => ucfirst($provider) . ' ID',
+            ]
+        );
     }
 }


### PR DESCRIPTION
This PR modernizes the `SocialLoginController` by:

* Refactoring the OAuth logic to be dynamic and provider-agnostic via a config array
* Removing repetitive logic for each provider (DRY)
* Implementing automatic user creation if no matching email is found
* Adding proper user property association for each provider (e.g., Discord ID)
* Wrapping the login flow in a DB transaction with proper error logging and fallback
* Supporting better email/name extraction from each OAuth response
* Improving maintainability and reducing duplication across provider logic

This change preps the controller for easier future provider integration and adds more resilience in handling unexpected failures or missing data.