### PR TITLE
Refactor Passport Scope Handling with ScopeRegistry

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use App\Models\EmailLog;
 use App\Models\Extension;
 use App\Models\OauthClient;
 use App\Models\User;
+use App\Support\Passport\ScopeRegistry;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
@@ -92,9 +93,7 @@ class AppServiceProvider extends ServiceProvider
         });
         Passport::clientModel(OauthClient::class);
         Passport::ignoreRoutes();
-        Passport::tokensCan([
-            'profile' => 'View your profile',
-        ]);
+        Passport::tokensCan(ScopeRegistry::getAll());
 
         if (class_exists(Scramble::class)) {
             Scramble::configure()

--- a/app/Support/Passport/ScopeRegistry.php
+++ b/app/Support/Passport/ScopeRegistry.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Support\Passport;
+
+class ScopeRegistry
+{
+    protected static array $scopes = [
+        'profile' => 'View your profile',
+    ];
+
+    public static function add(string $scope, string $description): void
+    {
+        if (!array_key_exists($scope, static::$scopes)) {
+            static::$scopes[$scope] = $description;
+        }
+    }
+
+    public static function addMany(array $scopes): void
+    {
+        foreach ($scopes as $key => $desc) {
+            static::add($key, $desc);
+        }
+    }
+
+    public static function getAll(): array
+    {
+        return static::$scopes;
+    }
+}


### PR DESCRIPTION
This PR introduces a new `ScopeRegistry` class to centralize and dynamically manage OAuth scopes used with Laravel Passport. This replaces the previously hardcoded `Passport::tokensCan([...])` in `AppServiceProvider`.

---

### ✅ What Changed

* **Replaced static scope declaration**:

  ```php
  Passport::tokensCan([
      'profile' => 'View your profile',
  ]);
  ```

  ➜ **Now uses**:

  ```php
  Passport::tokensCan(ScopeRegistry::getAll());
  ```

* **Added `ScopeRegistry` class** at `App\Support\Passport\ScopeRegistry`:

  * `add(string $scope, string $description)` – register a single scope
  * `addMany(array $scopes)` – register multiple scopes at once
  * `getAll(): array` – returns all registered scopes
  * Automatically avoids duplicate keys

* **Extensions can now register their own scopes** during `boot()`:

  ```php
  ScopeRegistry::addMany([
      'services.read' => 'View your services',
      'orders.read' => 'View your orders',
  ]);
  ```

* **No changes to middleware behavior** — routes using `scope:xxx` continue to work:

  ```php
  Route::get('/services', ...)->middleware('scope:services.read');
  ```

---

### 💡 Why This Matters

* **Scalability**: Hardcoding all scopes in `AppServiceProvider` doesn't scale for modular systems
* **Modularity**: Allows extensions or modules to self-register their required scopes without modifying the core
* **Maintainability**: Centralizes scope definitions, making them easier to track and update
* **Security**: Prevents duplicate or conflicting scope definitions

---

### How to Test

* Call an API route that uses `scope:*` middleware with a valid token:

  * Example: `/services` with `services.read` scope
* Register additional scopes inside an extension and ensure they're reflected in `Passport::tokensCan()`
* Check that unauthorized access (e.g., wrong or missing scope) still results in `403 Forbidden`

---

### 🚫 Breaking Changes

None. Existing scopes continue to function as-is. Default scopes like `profile` are still registered via `ScopeRegistry`.

---

### Affected Files

* `AppServiceProvider`
* `App\Support\Passport\ScopeRegistry`
* (Extensions that implement dynamic scope registration)

---

### Related

* Enables fully modular OAuth2 scope registration system
* Prepares for future scope expansion without touching core service provider
