### PR TITLE
fix: format expiration date display in services widget, list and details

### DIFF
--- a/themes/default/views/services/index.blade.php
+++ b/themes/default/views/services/index.blade.php
@@ -29,7 +29,7 @@
                 'period' => $service->plan->billing_period > 1 ? $service->plan->billing_period : '',
                 'unit' => trans_choice(__('services.billing_cycles.' . $service->plan->billing_unit),
                 $service->plan->billing_period)
-                ]) : '' }} - {{ $service->expires_at ? __('services.expires_at') . ': '. $service->expires_at->format('M d, Y') : '' }}
+                ]) : '' }} {{ $service->expires_at ? '- ' . __('services.expires_at') . ': '. $service->expires_at->format('M d, Y') : ''}}</p>
         </p>
         </div>
     </a>

--- a/themes/default/views/services/show.blade.php
+++ b/themes/default/views/services/show.blade.php
@@ -39,7 +39,7 @@
                     <div class="flex items-center text-base">
                         <span class="mr-2">{{ __('services.expires_at') }}:</span>
                         <span class="text-base/50">{{ $service->expires_at ? $service->expires_at->format('M d, Y')
-                            : '' }}</span>
+                            : 'N/A' }}</span>
                     </div>
                     @endif
                     <div class="flex items-center text-base">

--- a/themes/default/views/services/widget.blade.php
+++ b/themes/default/views/services/widget.blade.php
@@ -26,7 +26,7 @@
         <p class="text-base text-sm">Product(s): {{ $service->product->category->name }} {{ in_array($service->plan->type, ['recurring']) ? ' - ' . __('services.every_period', [
             'period' => $service->plan->billing_period > 1 ? $service->plan->billing_period : '',
             'unit' => trans_choice(__('services.billing_cycles.' . $service->plan->billing_unit), $service->plan->billing_period)
-        ]) : '' }}</p>
+        ]) : '' }} {{ $service->expires_at ? '- ' . __('services.expires_at') . ': '. $service->expires_at->format('M d, Y') : ''}}</p>
         </div>
     </a>
     @endforeach


### PR DESCRIPTION

Add expired information in the widget on the dashboard page:
<img width="734" height="246" alt="image" src="https://github.com/user-attachments/assets/0b7fa7c6-6dc8-4be5-b68c-74a7a5f5f60c" />

Fix the null or unset expired date in list of services:
<img width="482" height="224" alt="image" src="https://github.com/user-attachments/assets/8757593a-581d-48a2-bc9f-530f6ba5e6bc" />

Fix the null or unset expired date in the details of services:
<img width="421" height="235" alt="image" src="https://github.com/user-attachments/assets/9e6e9c24-4e10-47c8-8aa7-e21731a9b828" />
