### PR TITLE
Updated lang files

### DIFF
--- a/lang/id/dashboard.php
+++ b/lang/id/dashboard.php
@@ -2,7 +2,7 @@
 
 return [
     'dashboard_title' => 'Dasbor',
-    'welcome_back' => 'Selamat datang, {name}.',
+    'welcome_back' => 'Selamat datang, :name.',
     'dashboard_description' => 'Kelola layanan aktif, faktur, tiket Anda, dan tetap update disini.',
     'open_tickets' => 'Tiket Terbuka',
     'unpaid_invoices' => 'Tagihan belum dibayar',

--- a/lang/it/dashboard.php
+++ b/lang/it/dashboard.php
@@ -2,7 +2,7 @@
 
 return [
     'dashboard_title' => 'Dashboard',
-    'welcome_back' => 'Bentornato, {name}!',
+    'welcome_back' => 'Bentornato, :name!',
     'dashboard_description' => 'Gestisci i servizi attivi, le fatture, i biglietti e rimani aggiornato qui.',
     'open_tickets' => 'Ticket Aperti',
     'unpaid_invoices' => ' Fatture non pagate',

--- a/lang/ko/dashboard.php
+++ b/lang/ko/dashboard.php
@@ -2,7 +2,7 @@
 
 return [
     'dashboard_title' => '대시보드',
-    'welcome_back' => '환영합니다, {name}!',
+    'welcome_back' => '환영합니다, :name!',
     'dashboard_description' => 'Manage your active services, invoices, tickets, and stay updated here.',
     'open_tickets' => '티켓 열기',
     'unpaid_invoices' => '미납된 청구서',

--- a/lang/pl/dashboard.php
+++ b/lang/pl/dashboard.php
@@ -2,7 +2,7 @@
 
 return [
     'dashboard_title' => 'Panel',
-    'welcome_back' => 'Witaj z powrotem, {name}!',
+    'welcome_back' => 'Witaj z powrotem, :name!',
     'dashboard_description' => 'Zarządzaj aktywnymi usługami, fakturami, zgłoszeniami i bądź tutaj na bieżąco.',
     'open_tickets' => 'Otwarte zgłoszenia',
     'unpaid_invoices' => 'Nieopłacone faktury',

--- a/lang/zh/dashboard.php
+++ b/lang/zh/dashboard.php
@@ -2,7 +2,7 @@
 
 return [
     'dashboard_title' => '客戶中心',
-    'welcome_back' => '歡迎回來，{name}！',
+    'welcome_back' => '歡迎回來，name！',
     'dashboard_description' => '在這裡管理您啟用中的服務、帳單、服務單，並保持最新狀態。',
     'open_tickets' => '處理中的服務單',
     'unpaid_invoices' => '未付款的帳單',

--- a/lang/zh/dashboard.php
+++ b/lang/zh/dashboard.php
@@ -2,7 +2,7 @@
 
 return [
     'dashboard_title' => '客戶中心',
-    'welcome_back' => '歡迎回來，name！',
+    'welcome_back' => '歡迎回來，:name！',
     'dashboard_description' => '在這裡管理您啟用中的服務、帳單、服務單，並保持最新狀態。',
     'open_tickets' => '處理中的服務單',
     'unpaid_invoices' => '未付款的帳單',


### PR DESCRIPTION
Hi,

I've noticed some minors errors which caused the "name" placeholder to not load correctly in the following files for the "**_dashboard.welcome_back_**" lang placeholder:

- it
- zh
- id
- pl
- ko

<img width="673" height="178" alt="Screenshot 2025-08-03 alle 22 54 29" src="https://github.com/user-attachments/assets/7c5f7bce-2d07-4d94-aa5e-90bb1232a773" />

> **P.S.**
> _Sorry if I haven't followed a PR template and I've made 6 different commits in my fork, but I've just noticed and did it real quick using GitHub web before going to sleep 😅_