### PR TITLE
fix(ext): Wrong swap description

### DIFF
--- a/extensions/Servers/Pterodactyl/Pterodactyl.php
+++ b/extensions/Servers/Pterodactyl/Pterodactyl.php
@@ -144,7 +144,7 @@ class Pterodactyl extends Server
                 'min_value' => -1,
                 'suffix' => 'MiB',
                 'required' => true,
-                'description' => 'Set to 0 for unlimited, or to -1 to disable swap',
+                'description' => 'Set to -1 for unlimited, or to 0 to disable swap',
             ],
             [
                 'name' => 'disk',


### PR DESCRIPTION
Yea that's my bad. Did it the wrong way around in #793

Proof from Pterodactyl:
<img width="564" height="106" alt="image" src="https://github.com/user-attachments/assets/fb6f9a70-0b40-4cd1-b596-8d6d7eddc47f" />
