### PR TITLE
fix: email template disable

### DIFF
--- a/app/Models/EmailTemplate.php
+++ b/app/Models/EmailTemplate.php
@@ -13,12 +13,14 @@ class EmailTemplate extends Model
         'key',
         'name',
         'subject',
+        'enabled',
         'body',
         'cc',
         'bcc',
     ];
 
     protected $casts = [
+        'enabled' => 'boolean',
         'cc' => 'array',
         'bcc' => 'array',
     ];


### PR DESCRIPTION
adds the missing `enabled` key in the fillable array which led to issues in disabling email templates from use