### PR TITLE
DM reminders with discord bot

### DIFF
--- a/app/Classes/Settings.php
+++ b/app/Classes/Settings.php
@@ -492,6 +492,22 @@ class Settings
                     'default' => 'wavatar',
                 ],
                 [
+                    'name' => 'discord_dm_enabled',
+                    'label' => 'Enable Discord DM Notifications',
+                    'type' => 'checkbox',
+                    'database_type' => 'boolean',
+                    'default' => false,
+                    'description' => 'Allow users to receive invoice/service notifications via Discord DM.'
+                ],
+                [
+                    'name' => 'discord_bot_token',
+                    'label' => 'Discord Bot Token',
+                    'type' => 'text',
+                    'default' => '',
+                    'required' => false,
+                    'description' => 'The token of your Discord bot. This bot will be used to send DMs to users for invoice and service notifications.'
+                ],
+                [
                     'name' => 'default_currency',
                     'label' => 'Default Currency',
                     'type' => 'select',

--- a/app/Helpers/DiscordHelper.php
+++ b/app/Helpers/DiscordHelper.php
@@ -1,0 +1,99 @@
+<?php
+namespace App\Helpers;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use App\Models\User;
+use App\Classes\Settings;
+
+class DiscordHelper
+{
+    /**
+     * Send a direct message to a Discord user by user ID.
+     *
+     * @param string $discordUser Discord user ID (numeric)
+     * @param string|array $message Message content (plain text or embed array)
+     * @return bool True on success, false on failure
+     */
+    public static function sendDM($discordUser, $message)
+    {
+        $token = Settings::getSetting('discord_bot_token')->value ?? null;
+        Log::debug('DiscordHelper: DEBUG - About to send DM', [
+            'token_first_8' => $token ? substr($token, 0, 8) : null,
+            'token_length' => $token ? strlen($token) : 0,
+            'raw_token' => $token,
+            'discordUser' => $discordUser,
+            'discordUser_type' => gettype($discordUser),
+            'message' => $message,
+            'called_from' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)
+        ]);
+        if (!$token || !$discordUser) {
+            Log::warning('DiscordHelper: Missing bot token or user.', [
+                'token_present' => (bool)$token,
+                'discordUser' => $discordUser
+            ]);
+            return false;
+        }
+
+        // Only user IDs are supported for DMs
+        $userId = preg_match('/^\d{17,20}$/', $discordUser) ? $discordUser : null;
+        if (!$userId) {
+            Log::warning('DiscordHelper: Only user ID supported for DM.', [
+                'discordUser' => $discordUser
+            ]);
+            return false;
+        }
+
+        // Create DM channel with the user
+        Log::debug('DiscordHelper: Creating DM channel', [
+            'endpoint' => 'https://discord.com/api/v10/users/@me/channels',
+            'recipient_id' => $userId
+        ]);
+        $response = Http::withHeaders([
+            'Authorization' => 'Bot ' . $token,
+            'Content-Type' => 'application/json'
+        ])->post('https://discord.com/api/v10/users/@me/channels', [
+            'recipient_id' => $userId
+        ]);
+        Log::debug('DiscordHelper: DM channel creation response', [
+            'status' => $response->status(),
+            'body' => $response->body(),
+            'json' => $response->json()
+        ]);
+        if (!$response->ok() || !isset($response['id'])) {
+            Log::error('DiscordHelper: Failed to create DM channel', [
+                'status' => $response->status(),
+                'body' => $response->body(),
+                'json' => $response->json(),
+                'token_first_8' => substr($token, 0, 8)
+            ]);
+            return false;
+        }
+        $channelId = $response['id'];
+
+        // Send message
+        Log::debug('DiscordHelper: Sending message to DM channel', [
+            'channelId' => $channelId,
+            'payload' => $message
+        ]);
+        $payload = is_array($message) ? $message : ['content' => $message];
+        $msgResponse = Http::withHeaders([
+            'Authorization' => 'Bot ' . $token,
+            'Content-Type' => 'application/json'
+        ])->post("https://discord.com/api/v10/channels/{$channelId}/messages", $payload);
+        Log::debug('DiscordHelper: Message send response', [
+            'status' => $msgResponse->status(),
+            'body' => $msgResponse->body(),
+            'json' => $msgResponse->json()
+        ]);
+        if (!$msgResponse->ok()) {
+            Log::error('DiscordHelper: Failed to send DM', [
+                'status' => $msgResponse->status(),
+                'body' => $msgResponse->body(),
+                'json' => $msgResponse->json()
+            ]);
+            return false;
+        }
+        return true;
+    }
+}

--- a/app/Helpers/NotificationHelperDiscord.php
+++ b/app/Helpers/NotificationHelperDiscord.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Helpers;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\URL;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Http;
+use App\Models\User;
+use App\Models\Invoice;
+
+class NotificationHelperDiscord
+{
+    /**
+     * Send a Discord DM to the user if enabled and discord_id is valid.
+     */
+    public static function sendDiscordDM(User $user, $message): void
+    {
+        $discordSetting = \App\Classes\Settings::getSetting('discord_dm_enabled');
+        if (empty($discordSetting->value) || $discordSetting->value === '0' || $discordSetting->value === 0 || $discordSetting->value === false) {
+            Log::info('Discord DM not sent: setting disabled', ['user_id' => $user->id]);
+            return;
+        }
+        if (!empty($user->discord_id) && preg_match('/^\d{17,20}$/', $user->discord_id)) {
+            Log::info('Attempting Discord DM by discord_id', ['user_id' => $user->id, 'discord_id' => $user->discord_id]);
+            $result = \App\Helpers\DiscordHelper::sendDM($user->discord_id, $message);
+            Log::info('Discord DM result', ['result' => $result]);
+        } else {
+            Log::warning('Discord DM not sent: discord_id missing or invalid', ['user_id' => $user->id, 'discord_id' => $user->discord_id ?? null]);
+        }
+    }
+
+    /**
+     * Send a Discord DM when an invoice is paid.
+     */
+    public static function invoicePaidNotification(User $user, Invoice $invoice): void
+    {
+        $invoiceUrl = url("/invoices/{$invoice->id}");
+        $company = config('app.name', 'Our Company');
+        $embed = [
+            'embeds' => [[
+                'title' => '✅ Invoice Paid',
+                'color' => 0x43B581,
+                'fields' => [
+                    [ 'name' => 'Invoice #', 'value' => "#{$invoice->number}", 'inline' => true ],
+                    [ 'name' => 'Amount', 'value' => (string)$invoice->formattedTotal, 'inline' => true ],
+                ],
+                'description' => "Thank you for your payment!\n[View Invoice]({$invoiceUrl})",
+                'footer' => [ 'text' => $company ],
+            ]]
+        ];
+        $discordSetting = \App\Classes\Settings::getSetting('discord_dm_enabled');
+        if (!empty($discordSetting->value) && $discordSetting->value !== '0' && $discordSetting->value !== 0 && $discordSetting->value !== false) {
+            if (!empty($user->discord_id) && preg_match('/^\d{17,20}$/', $user->discord_id)) {
+                \App\Helpers\DiscordHelper::sendDM($user->discord_id, $embed);
+            }
+        }
+    }
+
+    /**
+     * (Unused) Placeholder for service cancellation Discord notification.
+     */
+    public static function serviceCancellationReceivedNotification(User $user, \App\Models\ServiceCancellation $cancellation, array $data = []): void
+    {
+        $data['cancellation'] = $cancellation;
+        $data['service'] = $cancellation->service;
+        // ...existing code...
+    }
+
+    /**
+     * Send a Discord DM when a new invoice is created.
+     */
+    public static function sendInvoiceCreatedDiscordDM(User $user, Invoice $invoice): void
+    {
+        $company = Config::get('app.name', 'Our Company');
+        $invoiceUrl = URL::to("/invoices/{$invoice->id}");
+        $dueDate = ($invoice->due_at ?? null) ? (is_object($invoice->due_at) ? $invoice->due_at->format('F j, Y') : Carbon::parse($invoice->due_at)->format('F j, Y')) : 'N/A';
+        $embed = [
+            'embeds' => [[
+                'title' => '🧾 New Invoice Created',
+                'color' => 0x7289DA,
+                'description' => "A new invoice has been generated for your account.\n[View & Pay Invoice]({$invoiceUrl})",
+                'fields' => [
+                    [ 'name' => 'Invoice #', 'value' => "#{$invoice->number}", 'inline' => true ],
+                    [ 'name' => 'Amount Due', 'value' => (string)$invoice->formattedTotal, 'inline' => true ],
+                    [ 'name' => 'Due Date', 'value' => ($dueDate !== 'N/A' ? "`{$dueDate}`" : '*N/A*'), 'inline' => false ],
+                ],
+                'footer' => [ 'text' => $company ],
+            ]]
+        ];
+        self::sendDiscordDM($user, $embed);
+    }
+
+    /**
+     * Send a Discord DM when an invoice is paid.
+     */
+    public static function sendInvoicePaidDiscordDM(User $user, Invoice $invoice): void
+    {
+        $company = Config::get('app.name', 'Our Company');
+        $invoiceUrl = URL::to("/invoices/{$invoice->id}");
+        $embed = [
+            'embeds' => [[
+                'title' => '✅ Invoice Paid',
+                'color' => 0x43B581,
+                'fields' => [
+                    [ 'name' => 'Invoice #', 'value' => "#{$invoice->number}", 'inline' => true ],
+                    [ 'name' => 'Amount', 'value' => (string)$invoice->formattedTotal, 'inline' => true ],
+                ],
+                'description' => "Thank you for your payment!\n[View Invoice]({$invoiceUrl})",
+                'footer' => [ 'text' => $company ],
+            ]]
+        ];
+        self::sendDiscordDM($user, $embed);
+    }
+}

--- a/app/Listeners/InvoicePaidListener.php
+++ b/app/Listeners/InvoicePaidListener.php
@@ -73,5 +73,8 @@ class InvoicePaidListener
                 }
             }
         });
+
+        // Send Discord DM for invoice payment
+    \App\Helpers\NotificationHelperDiscord::sendInvoicePaidDiscordDM($event->invoice->user, $event->invoice);
     }
 }

--- a/app/Listeners/SendMailListener.php
+++ b/app/Listeners/SendMailListener.php
@@ -8,6 +8,7 @@ use App\Events\Order\Finalized as OrderFinalized;
 use App\Events\ServiceCancellation\Created as CancellationCreated;
 use App\Events\User\Created as UserCreated;
 use App\Helpers\NotificationHelper;
+use App\Helpers\NotificationHelperDiscord;
 use App\Models\Session;
 
 class SendMailListener
@@ -25,6 +26,7 @@ class SendMailListener
 
             $invoice = $event->invoice;
             NotificationHelper::invoiceCreatedNotification($invoice->user, $invoice);
+            NotificationHelperDiscord::sendInvoiceCreatedDiscordDM($invoice->user, $invoice);
         } elseif ($event instanceof UserCreated) {
             $user = $event->user;
             NotificationHelper::emailVerificationNotification($user);

--- a/app/Livewire/Client/Account.php
+++ b/app/Livewire/Client/Account.php
@@ -12,6 +12,7 @@ class Account extends ComponentWithProperties
     public string $last_name = '';
 
     public string $email = '';
+    public string $discord_id = '';
 
     public function mount()
     {
@@ -20,6 +21,7 @@ class Account extends ComponentWithProperties
         $this->first_name = $user->first_name;
         $this->last_name = $user->last_name;
         $this->email = $user->email;
+    $this->discord_id = $user->discord_id ?? '';
 
         $this->initializeProperties($user, $user::class);
     }
@@ -30,6 +32,7 @@ class Account extends ComponentWithProperties
             'first_name' => 'required|string|max:255',
             'last_name' => 'required|string|max:255',
             'email' => 'required|email|max:255|unique:users,email,' . Auth::id(),
+            'discord_id' => 'nullable|string|max:25',
         ], $this->getRulesForProperties());
     }
 
@@ -45,6 +48,11 @@ class Account extends ComponentWithProperties
         /** @var \App\Models\User $user */
         $user = Auth::user();
         $user->update($validatedData);
+        $user->first_name = $validatedData['first_name'];
+        $user->last_name = $validatedData['last_name'];
+        $user->email = $validatedData['email'];
+    $user->discord_id = $validatedData['discord_id'] ?? null;
+        $user->save();
 
         if (array_key_exists('properties', $validatedData)) {
             $this->updateProperties($user, $validatedData['properties']);

--- a/database/migrations/2025_08_12_000001_add_discord_id_to_users_table.php
+++ b/database/migrations/2025_08_12_000001_add_discord_id_to_users_table.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('discord_id', 25)->nullable()->after('discord_username');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('discord_id');
+        });
+    }
+};

--- a/themes/default/views/client/account/index.blade.php
+++ b/themes/default/views/client/account/index.blade.php
@@ -9,8 +9,18 @@
             <x-form.input name="last_name" type="text" :label="__('general.input.last_name')"
                 :placeholder="__('general.input.last_name_placeholder')" wire:model="last_name" required dirty />
 
+
             <x-form.input name="email" type="email" :label="__('general.input.email')"
                 :placeholder="__('general.input.email_placeholder')" required wire:model="email" dirty />
+
+
+            @php
+                $discordDmEnabled = \App\Classes\Settings::getSetting('discord_dm_enabled')->value ?? false;
+            @endphp
+            @if($discordDmEnabled)
+                <x-form.input name="discord_id" type="text" label="Discord User ID"
+                    placeholder="e.g. 123456789012345678" wire:model="discord_id" dirty />
+            @endif
 
             <x-form.properties :custom_properties="$custom_properties" :properties="$properties" dirty />
         </div>


### PR DESCRIPTION
Added a bot token option in the settings and added a discord id option in the personal details tab of a user. The discord bot, of course, has to be in the same discord server as the user to work, and it HAS to be a discord id. But its a base that works flawlessly so far. I could attempt to make it work with the discord sign in option instead, but i think this is better as it allows users that aren't signed in with discord to also get dm reminders. Maybe something that gets the user id  from their discord username could also work better. Let me know if you have any concerns please

<img width="1204" height="443" alt="Screenshot 2025-08-12 155901" src="https://github.com/user-attachments/assets/8ebfd860-19ea-4730-b57d-c279c386aec3" />
<img width="995" height="849" alt="Screenshot 2025-08-12 155927" src="https://github.com/user-attachments/assets/454cca41-0ca3-4523-a8cf-32714e22dfa3" />
<img width="415" height="250" alt="Screenshot 2025-08-12 160147" src="https://github.com/user-attachments/assets/244a6595-021e-4dbe-b357-930f843c0924" />
<img width="278" height="214" alt="Screenshot 2025-08-12 160153" src="https://github.com/user-attachments/assets/df06b643-a6c0-48f8-b862-787973c16b87" />
