### PR TITLE
fix: prevent select component error when reopening payment pages

### DIFF
--- a/themes/default/views/components/select.blade.php
+++ b/themes/default/views/components/select.blade.php
@@ -17,7 +17,8 @@
                 this.selectPositionUpdate();
             });
 
-            window.addEventListener('resize', () => this.selectPositionUpdate());
+            window.addEventListener('resize', this.resizeHandler = () => this.selectPositionUpdate());
+            this.$el.addEventListener('alpine:destroyed', () => window.removeEventListener('resize', this.resizeHandler));
         },
 
         selectableItemIsActive(item) {
@@ -50,6 +51,8 @@
         },
 
         selectPositionUpdate() {
+            if (!this.$refs.selectButton || !this.$refs.selectableItemsList) return;
+            
             const selectDropdownBottomPos = this.$refs.selectButton.getBoundingClientRect().top + 
                 this.$refs.selectButton.offsetHeight + 
                 this.$refs.selectableItemsList.offsetHeight;


### PR DESCRIPTION
Select component throws error when reopening payment page after closing