### PR TITLE
UI adjustments for price tags on small screen

### DIFF
--- a/app/Livewire/Products/Checkout.php
+++ b/app/Livewire/Products/Checkout.php
@@ -43,13 +43,6 @@ class Checkout extends Component
     public function mount($product)
     {
         $this->product = $this->category->products()->where('slug', $product)->firstOrFail();
-        
-        $this->product->load(['configOptions' => function ($query) {
-            $query->orderBy('sort', 'asc')->orderBy('id', 'desc');
-        }, 'configOptions.children' => function ($query) {
-            $query->orderBy('sort', 'asc');
-        }]);
-
         if ($this->product->stock === 0) {
             return $this->redirect(route('products.show', ['category' => $this->category, 'product' => $this->product]), true);
         }


### PR DESCRIPTION
This pull request fixes the display of product configuration options and their pricing in the checkout flow. The main changes adjust the visibility of price tags for a better user experience on different screen sizes.

**UI adjustments for price tags on small screen:**
* In `themes/default/views/components/form/configoption.blade.php`, the price tag for child configuration options is now hidden on small screens and only shown on large screens, improving layout and readability. 

before
<img width="532" height="459" alt="image" src="https://github.com/user-attachments/assets/997c1de3-5428-42f0-856d-77e231807a48" />

after
<img width="529" height="432" alt="image" src="https://github.com/user-attachments/assets/24789e2d-d2d3-4ac3-8a14-cb9402ec0bdb" />

