### PR TITLE
feat: text fields in getAction

### DIFF
--- a/app/Livewire/Services/Show.php
+++ b/app/Livewire/Services/Show.php
@@ -18,6 +18,9 @@ class Show extends Component
     #[Locked]
     public $views = [];
 
+    #[Locked]
+    public $fields = [];
+
     #[Url('tab', except: false), Locked]
     public $currentView;
 
@@ -39,6 +42,8 @@ class Show extends Component
                     $this->buttons[] = $action;
                 } elseif ($action['type'] == 'view') {
                     $this->views[] = $action;
+                } elseif ($action['type'] == 'text') {
+                    $this->fields[] = $action;
                 }
             }
             $this->currentView = $this->currentView ?? ($this->views[0]['name'] ?? null);

--- a/themes/default/views/services/show.blade.php
+++ b/themes/default/views/services/show.blade.php
@@ -111,7 +111,7 @@
                     @else
                     <a href="{{ $button['url'] }}"
                         @if(!empty($button['target'])) target="{{ $button['target'] }}" @endif
-                        @if(($button['target'] ?? null)==='_blank' ) rel="noopener noreferrer" @endif>
+                        @if(($button['target'] ?? null) === '_blank') rel="noopener noreferrer" @endif>
                         <x-button.primary class="h-fit !w-fit">
                             {{ $button['label'] }}
                         </x-button.primary>

--- a/themes/default/views/services/show.blade.php
+++ b/themes/default/views/services/show.blade.php
@@ -109,7 +109,7 @@
                     @else
                     <a href="{{ $button['url'] }}"
                         @if(!empty($button['target'])) target="{{ $button['target'] }}" @endif
-                        @if(($button['target'] ?? null)==='_blank' ) rel="noopener noreferrer" @endif>
+                        @if(($button['target'] ?? null) === '_blank') rel="noopener noreferrer" @endif>
                         <x-button.primary class="h-fit !w-fit">
                             {{ $button['label'] }}
                         </x-button.primary>

--- a/themes/default/views/services/show.blade.php
+++ b/themes/default/views/services/show.blade.php
@@ -51,12 +51,10 @@
                     </div>
                     <br>
                     @foreach ($fields as $field)
-                    @if (isset($field['label']) && isset($field['text']))
                     <div class="flex items-center text-base">
                         <span class="mr-2">{{ $field['label'] }}:</span>
                         <span class="text-base/50">{{ $field['text'] }}</span>
                     </div>
-                    @endif
                     @endforeach
 
                 </div>
@@ -111,7 +109,7 @@
                     @else
                     <a href="{{ $button['url'] }}"
                         @if(!empty($button['target'])) target="{{ $button['target'] }}" @endif
-                        @if(($button['target'] ?? null) === '_blank') rel="noopener noreferrer" @endif>
+                        @if(($button['target'] ?? null)==='_blank' ) rel="noopener noreferrer" @endif>
                         <x-button.primary class="h-fit !w-fit">
                             {{ $button['label'] }}
                         </x-button.primary>

--- a/themes/default/views/services/show.blade.php
+++ b/themes/default/views/services/show.blade.php
@@ -49,6 +49,16 @@
                             {{ __('services.statuses.' . $service->status) }}
                         </span>
                     </div>
+                    <br>
+                    @foreach ($fields as $field)
+                    @if (isset($field['label']) && isset($field['text']))
+                    <div class="flex items-center text-base">
+                        <span class="mr-2">{{ $field['label'] }}:</span>
+                        <span class="text-base/50">{{ $field['text'] }}</span>
+                    </div>
+                    @endif
+                    @endforeach
+
                 </div>
             </div>
             @if($service->cancellable || $service->upgradable || count($buttons) > 0)
@@ -101,7 +111,7 @@
                     @else
                     <a href="{{ $button['url'] }}"
                         @if(!empty($button['target'])) target="{{ $button['target'] }}" @endif
-                        @if(($button['target'] ?? null) === '_blank') rel="noopener noreferrer" @endif>
+                        @if(($button['target'] ?? null)==='_blank' ) rel="noopener noreferrer" @endif>
                         <x-button.primary class="h-fit !w-fit">
                             {{ $button['label'] }}
                         </x-button.primary>


### PR DESCRIPTION
Added custom fields to `getActions`, letting extension add more fields when needed.
For example, HestiaCP don't have SSO link, therefore simple button won't help.

The API for adding text field:
```php
    public function getActions(Service $service, $settings, $properties): array
    {
        if (!isset($properties['hestiacp_username'])) {
            return [];
        }

        return [
            [
                'type' => 'text',
                'text' => $properties['hestiacp_username'],
                'label' => 'HestiaCP Username',
            ],
            [
                'type' => 'text',
                'text' => $properties['hestiacp_password'],
                'label' => 'HestiaCP Password',
            ]
        ];
    }
```

How it's look like:
<img width="1119" height="350" alt="image" src="https://github.com/user-attachments/assets/f3c33814-e753-4bb9-bf2b-fb32548a52c2" />

Solves #939.