### PR TITLE
Cast billing_period to integer

### DIFF
--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -22,6 +22,18 @@ class Plan extends Model implements Auditable
     ];
 
     /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'billing_period' => 'integer',
+        ];
+    }
+
+    /**
      * Get the available prices of the plan.
      */
     public function prices()

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -20,18 +20,10 @@ class Plan extends Model implements Auditable
         'billing_unit',
         'sort',
     ];
-
-    /**
-     * Get the attributes that should be cast.
-     *
-     * @return array<string, string>
-     */
-    protected function casts(): array
-    {
-        return [
-            'billing_period' => 'integer',
-        ];
-    }
+    
+    protected $casts = [
+        'billing_period' => 'integer',
+    ];
 
     /**
      * Get the available prices of the plan.


### PR DESCRIPTION
This commit addresses a TypeError that occurred during checkout. The billing_period field, which should be an integer, was sometimes being typed as a string.

The fix ensures that billing_period is explicitly cast to an integer before it is used to calculate the end date, preventing the TypeError and ensuring the checkout process functions correctly.

![error](https://i.ibb.co/Ldqj2rBY/image.png)