### PR TITLE
Fix possible issued with CVE-2025-58752  and CVE-2025-58751 in open Dev Environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
         "@tailwindcss/vite": "^4.1.11",
         "laravel-vite-plugin": "^2.0",
         "tailwindcss": "^4.1.11",
-        "vite": "^7.1"
+        "vite": "^7.1.5"
     }
 }


### PR DESCRIPTION
It is quite likely that it would never have become a real problem, as probably no one makes their dev environment publicly accessible. However, it's still important to prepare for the extremely unlikely (and foolish) scenario. (Especially if a significant proportion of users are under 18 and have 0 idea of what their doing).