### PR TITLE
feat: Custom properties: implementing conditional visibility and ordering

### DIFF
--- a/app/Admin/Resources/Common/RelationManagers/PropertiesRelationManager.php
+++ b/app/Admin/Resources/Common/RelationManagers/PropertiesRelationManager.php
@@ -27,7 +27,11 @@ class PropertiesRelationManager extends RelationManager
                 Select::make('custom_property_id')->label('Custom Property')
                     ->required()
                     ->options(function ($livewire): array {
-                        return CustomProperty::where('model', get_class($livewire->ownerRecord))->pluck('name', 'id')->toArray();
+                        return CustomProperty::where('model', get_class($livewire->ownerRecord))
+                            ->orderBy('sort_order')
+                            ->orderBy('name')
+                            ->pluck('name', 'id')
+                            ->toArray();
                     })->nullable(),
                 TextInput::make('name')->translateLabel()->nullable(),
                 TextInput::make('key')->translateLabel()->required(),

--- a/app/Admin/Resources/CustomPropertyResource.php
+++ b/app/Admin/Resources/CustomPropertyResource.php
@@ -9,20 +9,29 @@ use App\Models\CustomProperty;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Columns\ToggleColumn;
 use Filament\Tables\Table;
+use Filament\Actions\Action as TableAction;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\HtmlString;
 
 class CustomPropertyResource extends Resource
 {
+    protected static ?array $conditionPropertyOptionsCache = null;
+
+    protected static array $conditionValueOptionsCache = [];
+
     protected static ?string $model = CustomProperty::class;
 
     protected static string|\UnitEnum|null $navigationGroup = 'Configuration';
@@ -41,7 +50,13 @@ class CustomPropertyResource extends Resource
                 TextInput::make('key')->required(),
                 Select::make('model')->options([
                     'App\Models\User' => 'User',
-                ])->required(),
+                ])->required()->reactive(),
+                TextInput::make('sort_order')
+                    ->numeric()
+                    ->minValue(0)
+                    ->placeholder('Leave empty to append automatically.')
+                    ->helperText('Controls the display order in forms.')
+                    ->dehydrateStateUsing(fn ($state) => is_numeric($state) ? (int) $state : null),
                 Select::make('type')->options([
                     'string' => 'Short Text',
                     'text' => 'Long Text',
@@ -52,7 +67,33 @@ class CustomPropertyResource extends Resource
                     'date' => 'Date',
                 ])->required(),
                 Textarea::make('description')->nullable()->columnSpanFull()->rows(2),
-                TagsInput::make('allowed_values')->nullable(),
+                TagsInput::make('allowed_values')
+                    ->label('Allowed values')
+                    ->helperText('Required when the type is Select or Radio.')
+                    ->placeholder('Add values and press enter')
+                    ->default([])
+                    ->reactive()
+                    ->required(fn (Get $get) => in_array($get('type'), ['select', 'radio'], true))
+                    ->rules(fn (Get $get) => in_array($get('type'), ['select', 'radio'], true) ? ['required', 'array', 'min:1'] : ['nullable', 'array'])
+                    ->dehydrateStateUsing(function ($state) {
+                        if (! is_array($state)) {
+                            return [];
+                        }
+
+                        return collect($state)
+                            ->map(function ($value) {
+                                if (! is_scalar($value)) {
+                                    return null;
+                                }
+
+                                $trimmed = trim((string) $value);
+
+                                return $trimmed === '' ? null : $trimmed;
+                            })
+                            ->filter()
+                            ->values()
+                            ->all();
+                    }),
                 TextInput::make('validation')->nullable(),
 
                 Section::make()
@@ -65,6 +106,102 @@ class CustomPropertyResource extends Resource
                         Toggle::make('required')->default(false),
                         Toggle::make('show_on_invoice')->default(false),
                     ]),
+                Section::make('Visibility conditions')
+                    ->description('Control when this property is displayed based on other fields.')
+                    ->schema([
+                        Select::make('condition_mode')
+                            ->label('Condition combination')
+                            ->options([
+                                'none' => 'Without conditions',
+                                'all' => 'All conditions must match',
+                                'any' => 'Any condition may match',
+                            ])
+                            ->default('none')
+                            ->selectablePlaceholder(false)
+                            ->reactive()
+                            ->helperText('Select how the conditions should be evaluated.'),
+                        Repeater::make('condition_rules')
+                            ->label('Conditions')
+                            ->columns(1)
+                            ->default([])
+                            ->defaultItems(0)
+                            ->collapsed(false)
+                            ->visible(fn (callable $get) => ($get('condition_mode') ?? 'none') !== 'none')
+                            ->addActionLabel('Add condition')
+                            ->schema([
+                                Select::make('property_key')
+                                    ->label('Property')
+                                    ->options(fn () => self::getConditionPropertyOptions())
+                                    ->searchable()
+                                    ->required()
+                                    ->placeholder('Select a property'),
+                                Select::make('operator')
+                                    ->label('Operator')
+                                    ->options([
+                                        'equals' => 'Equals',
+                                        'not_equals' => 'Does not equal',
+                                        'in' => 'Is in list',
+                                        'not_in' => 'Is not in list',
+                                        'filled' => 'Is filled',
+                                        'blank' => 'Is blank',
+                                    ])
+                                    ->required()
+                                    ->reactive()
+                                    ->helperText('Choose how the selected property should be evaluated.'),
+                                Select::make('value_picker')
+                                    ->label('Value')
+                                    ->statePath('value')
+                                    ->native(false)
+                                    ->searchable()
+                                    ->options(fn (callable $get) => self::getConditionValueOptions($get('property_key')))
+                                    ->visible(fn (callable $get) => self::hasConditionValueOptions($get('property_key')) && in_array($get('operator'), ['equals', 'not_equals'], true))
+                                    ->placeholder('Select a value'),
+                                TextInput::make('value')
+                                    ->label('Value')
+                                    ->placeholder('Enter a value')
+                                    ->datalist(fn (callable $get) => array_values(self::getConditionValueOptions($get('property_key'))))
+                                    ->hidden(fn (callable $get) => in_array($get('operator'), ['equals', 'not_equals'], true) && self::hasConditionValueOptions($get('property_key')))
+                                    ->dehydrateStateUsing(fn ($state, callable $get) => in_array($get('operator'), ['equals', 'not_equals'], true) && is_string($state) && trim($state) !== '' ? trim($state) : null),
+                                Select::make('values_picker')
+                                    ->label('Values')
+                                    ->statePath('values')
+                                    ->native(false)
+                                    ->multiple()
+                                    ->searchable()
+                                    ->options(fn (callable $get) => self::getConditionValueOptions($get('property_key')))
+                                    ->visible(fn (callable $get) => in_array($get('operator'), ['in', 'not_in'], true) && self::hasConditionValueOptions($get('property_key')))
+                                    ->placeholder('Select values'),
+                                TagsInput::make('values')
+                                    ->label('Values')
+                                    ->placeholder('Add values and press enter')
+                                    ->suggestions(fn (callable $get) => array_values(self::getConditionValueOptions($get('property_key'))))
+                                    ->hidden(fn (callable $get) => ! in_array($get('operator'), ['in', 'not_in'], true) || self::hasConditionValueOptions($get('property_key')))
+                                    ->dehydrateStateUsing(function ($state, callable $get) {
+                                        if (! in_array($get('operator'), ['in', 'not_in'], true)) {
+                                            return [];
+                                        }
+
+                                        if (! is_array($state)) {
+                                            return [];
+                                        }
+
+                                        return collect($state)
+                                            ->map(function ($value) {
+                                                if (! is_string($value)) {
+                                                    return null;
+                                                }
+
+                                                $trimmed = trim($value);
+
+                                                return $trimmed === '' ? null : $trimmed;
+                                            })
+                                            ->filter()
+                                            ->values()
+                                            ->all();
+                                    }),
+                            ]),
+                    ])
+                    ->collapsed(),
             ]);
     }
 
@@ -73,21 +210,67 @@ class CustomPropertyResource extends Resource
         return $table
             ->columns([
                 TextColumn::make('name')->label('Property')
-                    ->description(fn (CustomProperty $record): string => mb_strimwidth(($record->description ?? ''),
-                        0,
-                        75,
-                        '...'
-                    )),
+                    ->description(function (CustomProperty $record): ?HtmlString {
+                        $rawDescription = trim((string) ($record->description ?? ''));
+
+                        if ($rawDescription === '') {
+                            return null;
+                        }
+
+                        $wrapped = wordwrap($rawDescription, 80, "\n");
+                        $lines = preg_split('/\r\n|\r|\n/', $wrapped) ?: [];
+
+                        if ($lines === []) {
+                            return new HtmlString(e($rawDescription));
+                        }
+
+                        $hasOverflow = count($lines) > 2;
+                        $lines = array_slice($lines, 0, 2);
+
+                        if ($hasOverflow) {
+                            $lastIndex = count($lines) - 1;
+                            $lines[$lastIndex] = rtrim($lines[$lastIndex]) . '...';
+                        }
+
+                        $escapedLines = array_map(static fn (string $line): string => e($line), $lines);
+
+                        return new HtmlString(implode('<br>', $escapedLines));
+                    })
+                    ->wrap(),
                 TextColumn::make('key'),
                 TextColumn::make('type')->formatStateUsing(fn ($state) => str($state)->title()),
                 ToggleColumn::make('non_editable'),
                 ToggleColumn::make('required'),
                 ToggleColumn::make('show_on_invoice'),
             ])
+            ->defaultSort('sort_order')
+            ->reorderable('sort_order')
             ->filters([
                 //
             ])
             ->recordActions([
+                TableAction::make('move_up')
+                    ->label('Move up')
+                    ->icon('heroicon-o-arrow-up')
+                    ->color('gray')
+                    ->iconButton()
+                    ->tooltip('Move property up')
+                    ->action(function (CustomProperty $record) {
+                        $record->moveOrderUp();
+                        $record->refresh();
+                    })
+                    ->visible(fn (CustomProperty $record): bool => $record->canMoveUp()),
+                TableAction::make('move_down')
+                    ->label('Move down')
+                    ->icon('heroicon-o-arrow-down')
+                    ->color('gray')
+                    ->iconButton()
+                    ->tooltip('Move property down')
+                    ->action(function (CustomProperty $record) {
+                        $record->moveOrderDown();
+                        $record->refresh();
+                    })
+                    ->visible(fn (CustomProperty $record): bool => $record->canMoveDown()),
                 EditAction::make(),
             ])
             ->toolbarActions([
@@ -111,5 +294,194 @@ class CustomPropertyResource extends Resource
             'create' => CreateCustomProperty::route('/create'),
             'edit' => EditCustomProperty::route('/{record}/edit'),
         ];
+    }
+
+    public static function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data = static::prepareConditionData($data);
+
+        return static::prepareSortOrder($data);
+    }
+
+    public static function mutateFormDataBeforeSave(array $data): array
+    {
+        $data = static::prepareConditionData($data);
+
+        return static::prepareSortOrder($data);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->orderBy('sort_order')
+            ->orderBy('name');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected static function getConditionPropertyOptions(): array
+    {
+        if (self::$conditionPropertyOptionsCache !== null) {
+            return self::$conditionPropertyOptionsCache;
+        }
+
+        return self::$conditionPropertyOptionsCache = CustomProperty::query()
+            ->orderBy('sort_order')
+            ->orderBy('name')
+            ->pluck('name', 'key')
+            ->toArray();
+    }
+
+    protected static function getConditionValueOptions(?string $propertyKey): array
+    {
+        if (! is_string($propertyKey) || trim($propertyKey) === '') {
+            return [];
+        }
+
+        if (array_key_exists($propertyKey, self::$conditionValueOptionsCache)) {
+            return self::$conditionValueOptionsCache[$propertyKey];
+        }
+
+        $property = CustomProperty::query()
+            ->where('key', $propertyKey)
+            ->first(['allowed_values']);
+
+        if (! $property || ! is_array($property->allowed_values)) {
+            return self::$conditionValueOptionsCache[$propertyKey] = [];
+        }
+
+        $options = collect($property->allowed_values)
+            ->map(function ($value) {
+                if (! is_scalar($value)) {
+                    return null;
+                }
+
+                $normalized = trim((string) $value);
+
+                return $normalized === '' ? null : $normalized;
+            })
+            ->filter()
+            ->unique()
+            ->mapWithKeys(fn ($value) => [$value => $value])
+            ->toArray();
+
+        return self::$conditionValueOptionsCache[$propertyKey] = $options;
+    }
+
+    protected static function hasConditionValueOptions(?string $propertyKey): bool
+    {
+        return self::getConditionValueOptions($propertyKey) !== [];
+    }
+
+    protected static function prepareConditionData(array $data): array
+    {
+        $mode = $data['condition_mode'] ?? 'none';
+
+        if ($mode === 'none') {
+            $data['condition_rules'] = null;
+
+            return $data;
+        }
+
+        if (! isset($data['condition_rules']) || ! is_array($data['condition_rules'])) {
+            $data['condition_rules'] = null;
+
+            return $data;
+        }
+
+        $data['condition_rules'] = collect($data['condition_rules'])
+            ->map(function ($condition) {
+                if (! is_array($condition)) {
+                    return null;
+                }
+
+                $propertyKey = isset($condition['property_key']) ? trim((string) $condition['property_key']) : '';
+
+                if ($propertyKey === '') {
+                    return null;
+                }
+
+                $operator = $condition['operator'] ?? null;
+
+                if (! is_string($operator) || trim($operator) === '') {
+                    return null;
+                }
+
+                $operator = strtolower($operator);
+
+                if (! in_array($operator, ['equals', 'not_equals', 'in', 'not_in', 'filled', 'blank'], true)) {
+                    return null;
+                }
+
+                $value = $condition['value'] ?? null;
+                $values = $condition['values'] ?? [];
+
+                if (in_array($operator, ['equals', 'not_equals'], true)) {
+                    $value = is_string($value) && trim($value) !== '' ? trim($value) : null;
+                    $values = [];
+                } elseif (in_array($operator, ['in', 'not_in'], true)) {
+                    if (! is_array($values)) {
+                        $values = is_string($values) ? preg_split('/[,;|]+/', $values) : [];
+                    }
+
+                    $values = collect($values)
+                        ->map(fn ($item) => is_scalar($item) ? trim((string) $item) : null)
+                        ->filter(fn ($item) => $item !== null && $item !== '')
+                        ->unique()
+                        ->values()
+                        ->all();
+
+                    $value = null;
+                } else {
+                    $value = null;
+                    $values = [];
+                }
+
+                return [
+                    'property_key' => $propertyKey,
+                    'operator' => $operator,
+                    'value' => $value,
+                    'values' => $values,
+                ];
+            })
+            ->filter()
+            ->values()
+            ->toArray();
+
+        if ($data['condition_rules'] === []) {
+            $data['condition_rules'] = null;
+        }
+
+        return $data;
+    }
+
+    protected static function prepareSortOrder(array $data): array
+    {
+        $model = isset($data['model']) && is_string($data['model'])
+            ? trim($data['model'])
+            : null;
+
+        if ($model === null || $model === '') {
+            unset($data['sort_order']);
+
+            return $data;
+        }
+
+        if (! isset($data['sort_order']) || $data['sort_order'] === null) {
+            $data['sort_order'] = CustomProperty::nextSortOrderForModel($model);
+
+            return $data;
+        }
+
+        if (! is_numeric($data['sort_order'])) {
+            $data['sort_order'] = CustomProperty::nextSortOrderForModel($model);
+
+            return $data;
+        }
+
+        $data['sort_order'] = max(0, (int) $data['sort_order']);
+
+        return $data;
     }
 }

--- a/app/Models/CustomProperty.php
+++ b/app/Models/CustomProperty.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use OwenIt\Auditing\Contracts\Auditable;
 
@@ -15,5 +16,102 @@ class CustomProperty extends Model implements Auditable
 
     public $casts = [
         'allowed_values' => 'array',
+        'condition_rules' => 'array',
+        'sort_order' => 'integer',
     ];
+
+    protected $attributes = [
+        'condition_mode' => 'none',
+        'sort_order' => 0,
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (CustomProperty $property): void {
+            if (! is_numeric($property->sort_order) && $property->model) {
+                $property->sort_order = static::nextSortOrderForModel($property->model);
+            }
+
+            if (is_numeric($property->sort_order)) {
+                $property->sort_order = max(0, (int) $property->sort_order);
+            }
+        });
+
+        static::saving(function (CustomProperty $property): void {
+            if (! is_numeric($property->sort_order) && $property->model) {
+                $property->sort_order = static::nextSortOrderForModel($property->model);
+            }
+
+            if (is_numeric($property->sort_order)) {
+                $property->sort_order = max(0, (int) $property->sort_order);
+            }
+        });
+    }
+
+    public static function nextSortOrderForModel(string $model): int
+    {
+        $max = static::query()
+            ->where('model', $model)
+            ->max('sort_order');
+
+        return is_numeric($max) ? ((int) $max + 1) : 0;
+    }
+
+    public function moveOrderUp(): void
+    {
+        $previous = $this->orderScope()
+            ->where('sort_order', '<', $this->sort_order ?? 0)
+            ->orderByDesc('sort_order')
+            ->first();
+
+        if (! $previous) {
+            return;
+        }
+
+        $this->swapSortOrderWith($previous);
+    }
+
+    public function moveOrderDown(): void
+    {
+        $next = $this->orderScope()
+            ->where('sort_order', '>', $this->sort_order ?? 0)
+            ->orderBy('sort_order')
+            ->first();
+
+        if (! $next) {
+            return;
+        }
+
+        $this->swapSortOrderWith($next);
+    }
+
+    public function canMoveUp(): bool
+    {
+        return $this->orderScope()
+            ->where('sort_order', '<', $this->sort_order ?? 0)
+            ->exists();
+    }
+
+    public function canMoveDown(): bool
+    {
+        return $this->orderScope()
+            ->where('sort_order', '>', $this->sort_order ?? 0)
+            ->exists();
+    }
+
+    protected function orderScope(): Builder
+    {
+        return static::query()->where('model', $this->model);
+    }
+
+    protected function swapSortOrderWith(self $other): void
+    {
+        $current = $this->sort_order ?? 0;
+        $target = $other->sort_order ?? 0;
+
+        static::withoutEvents(function () use ($other, $current, $target): void {
+            $this->forceFill(['sort_order' => $target])->saveQuietly();
+            $other->forceFill(['sort_order' => $current])->saveQuietly();
+        });
+    }
 }

--- a/app/Services/CustomPropertyVisibilityService.php
+++ b/app/Services/CustomPropertyVisibilityService.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\CustomProperty;
+use Illuminate\Support\Collection;
+
+class CustomPropertyVisibilityService
+{
+    public function filter(Collection $properties, array $currentValues = []): Collection
+    {
+        $values = $this->resolvePropertyValues($currentValues);
+
+        return $properties
+            ->values()
+            ->filter(fn (CustomProperty $property) => $this->shouldDisplayProperty($property, $values))
+            ->values();
+    }
+
+    protected function shouldDisplayProperty(CustomProperty $property, array $currentValues): bool
+    {
+        $mode = $property->condition_mode ?? 'none';
+
+        if ($mode === 'none') {
+            return true;
+        }
+
+        $conditions = $property->condition_rules;
+
+        if (! is_array($conditions) || $conditions === []) {
+            return true;
+        }
+
+        $results = collect($conditions)
+            ->filter(fn ($condition) => is_array($condition) && isset($condition['operator'], $condition['property_key']))
+            ->map(fn ($condition) => $this->evaluateCondition($condition, $currentValues))
+            ->filter(fn ($result) => $result !== null);
+
+        if ($results->isEmpty()) {
+            return true;
+        }
+
+        if ($mode === 'any') {
+            return $results->contains(true);
+        }
+
+        return $results->every(fn ($result) => $result === true);
+    }
+
+    protected function evaluateCondition(array $condition, array $currentValues): ?bool
+    {
+        $key = $condition['property_key'] ?? null;
+
+        if (! is_string($key) || trim($key) === '') {
+            return null;
+        }
+
+        $operator = strtolower((string) ($condition['operator'] ?? 'equals'));
+        $value = $currentValues[$key] ?? null;
+
+        return match ($operator) {
+            'equals' => $this->valuesAreEqual($key, $value, $condition['value'] ?? null),
+            'not_equals' => ! $this->valuesAreEqual($key, $value, $condition['value'] ?? null),
+            'in' => $this->valueInSet($key, $value, $condition['values'] ?? []),
+            'not_in' => ! $this->valueInSet($key, $value, $condition['values'] ?? []),
+            'filled' => filled($value),
+            'blank' => blank($value),
+            default => null,
+        };
+    }
+
+    protected function valueInSet(string $propertyKey, mixed $value, mixed $expected): bool
+    {
+        $expectedValues = $this->normalizeArray($expected);
+
+        if ($propertyKey === 'country') {
+            $expectedValues = collect($expectedValues)
+                ->merge(collect($expectedValues)->map(fn ($item) => $this->normalizeCountryValue($item)))
+                ->filter()
+                ->unique()
+                ->values()
+                ->all();
+        }
+
+        if ($expectedValues === []) {
+            return false;
+        }
+
+        if (is_array($value)) {
+            $normalized = $this->normalizeArray($value);
+
+            if ($propertyKey === 'country') {
+                $normalized = collect($normalized)
+                    ->merge(collect($normalized)->map(fn ($item) => $this->normalizeCountryValue($item)))
+                    ->filter()
+                    ->unique()
+                    ->values()
+                    ->all();
+            }
+
+            return collect($normalized)->intersect($expectedValues)->isNotEmpty();
+        }
+
+        if ($propertyKey === 'country') {
+            $candidates = array_filter([
+                $this->normalizeScalar($value),
+                $this->normalizeCountryValue($value),
+            ]);
+
+            foreach (array_unique($candidates) as $candidate) {
+                if (in_array($candidate, $expectedValues, true)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        $normalizedValue = $this->normalizeScalar($value);
+
+        if ($normalizedValue === null) {
+            return false;
+        }
+
+        return in_array($normalizedValue, $expectedValues, true);
+    }
+
+    protected function valuesAreEqual(string $propertyKey, mixed $first, mixed $second): bool
+    {
+        $normalizedFirst = $this->normalizeScalar($first);
+        $normalizedSecond = $this->normalizeScalar($second);
+
+        if ($propertyKey === 'country') {
+            $firstCountry = $this->normalizeCountryValue($first);
+            $secondCountry = $this->normalizeCountryValue($second);
+
+            if ($firstCountry !== null && $secondCountry !== null) {
+                return $firstCountry === $secondCountry;
+            }
+        }
+
+        return $normalizedFirst === $normalizedSecond;
+    }
+
+    protected function resolvePropertyValues(array $provided): array
+    {
+        if ($provided !== []) {
+            return $this->normalizeProvidedValues($provided);
+        }
+
+        return $this->normalizeProvidedValues($this->resolvePropertyValuesFromRequest());
+    }
+
+    protected function resolvePropertyValuesFromRequest(): array
+    {
+        $values = request()->input('properties');
+
+        if (is_array($values)) {
+            return $values;
+        }
+
+        $old = old('properties');
+
+        if (is_array($old)) {
+            return $old;
+        }
+
+        return [];
+    }
+
+    protected function normalizeProvidedValues(array $values): array
+    {
+        return collect($values)
+            ->map(function ($item) {
+                if (is_array($item)) {
+                    $normalized = $this->normalizeArray($item);
+
+                    if (count($normalized) === 1) {
+                        return $normalized[0];
+                    }
+
+                    return $normalized;
+                }
+
+                return $this->normalizeScalar($item) ?? $item;
+            })
+            ->toArray();
+    }
+
+    protected function normalizeScalar(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_numeric($value)) {
+            return (string) $value;
+        }
+
+        if (is_string($value)) {
+            $trimmed = trim($value);
+
+            return $trimmed === '' ? null : $trimmed;
+        }
+
+        return null;
+    }
+
+    protected function normalizeArray(mixed $value): array
+    {
+        if (is_array($value)) {
+            return collect($value)
+                ->map(fn ($item) => $this->normalizeScalar($item))
+                ->filter(fn ($item) => $item !== null && $item !== '')
+                ->values()
+                ->toArray();
+        }
+
+        if (is_string($value)) {
+            return collect(preg_split('/[,;|]+/', $value))
+                ->map(fn ($item) => $this->normalizeScalar($item))
+                ->filter(fn ($item) => $item !== null && $item !== '')
+                ->values()
+                ->toArray();
+        }
+
+        return [];
+    }
+
+    protected function normalizeCountryValue(mixed $value): ?string
+    {
+        if (is_array($value)) {
+            $value = reset($value);
+        }
+
+        $normalized = $this->normalizeScalar($value);
+
+        if ($normalized === null) {
+            return null;
+        }
+
+        $normalized = strtoupper($normalized);
+
+        if (strlen($normalized) === 2) {
+            return $normalized;
+        }
+
+        $countries = config('app.countries', []);
+
+        foreach ($countries as $code => $name) {
+            if (! is_string($code) || $code === '') {
+                continue;
+            }
+
+            if (strcasecmp((string) $name, $normalized) === 0) {
+                return strtoupper($code);
+            }
+        }
+
+        return $normalized;
+    }
+}

--- a/database/migrations/2025_10_16_000010_add_condition_fields_to_custom_properties_table.php
+++ b/database/migrations/2025_10_16_000010_add_condition_fields_to_custom_properties_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('custom_properties', function (Blueprint $table) {
+            $table->string('condition_mode', 16)->default('none')->after('show_on_invoice');
+            $table->json('condition_rules')->nullable()->after('condition_mode');
+            $table->integer('sort_order')->default(0)->after('condition_rules');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('custom_properties', function (Blueprint $table) {
+            $table->dropColumn(['condition_mode', 'condition_rules', 'sort_order']);
+        });
+    }
+};

--- a/database/seeders/CustomPropertySeeder.php
+++ b/database/seeders/CustomPropertySeeder.php
@@ -24,6 +24,9 @@ class CustomPropertySeeder extends Seeder
                 'required' => 1,
                 'show_on_invoice' => 0,
                 'validation' => 'string|max:255',
+                'condition_mode' => 'none',
+                'condition_rules' => null,
+                'sort_order' => 10,
             ],
             [
                 'key' => 'company_name',
@@ -34,6 +37,9 @@ class CustomPropertySeeder extends Seeder
                 'required' => 0,
                 'show_on_invoice' => 1,
                 'validation' => 'string|max:255',
+                'condition_mode' => 'none',
+                'condition_rules' => null,
+                'sort_order' => 20,
             ],
             [
                 'key' => 'address',
@@ -44,6 +50,9 @@ class CustomPropertySeeder extends Seeder
                 'required' => 1,
                 'show_on_invoice' => 1,
                 'validation' => 'string|max:255',
+                'condition_mode' => 'none',
+                'condition_rules' => null,
+                'sort_order' => 40,
             ],
             [
                 'key' => 'address2',
@@ -54,6 +63,9 @@ class CustomPropertySeeder extends Seeder
                 'required' => 0,
                 'show_on_invoice' => 0,
                 'validation' => 'string|max:255',
+                'condition_mode' => 'none',
+                'condition_rules' => null,
+                'sort_order' => 50,
             ],
             [
                 'key' => 'city',
@@ -64,6 +76,9 @@ class CustomPropertySeeder extends Seeder
                 'required' => 1,
                 'show_on_invoice' => 1,
                 'validation' => 'string|max:255',
+                'condition_mode' => 'none',
+                'condition_rules' => null,
+                'sort_order' => 60,
             ],
             [
                 'key' => 'state',
@@ -74,6 +89,9 @@ class CustomPropertySeeder extends Seeder
                 'required' => 1,
                 'show_on_invoice' => 1,
                 'validation' => 'string|max:255',
+                'condition_mode' => 'none',
+                'condition_rules' => null,
+                'sort_order' => 70,
             ],
             [
                 'key' => 'zip',
@@ -84,6 +102,9 @@ class CustomPropertySeeder extends Seeder
                 'required' => 1,
                 'show_on_invoice' => 1,
                 'validation' => 'string|max:255',
+                'condition_mode' => 'none',
+                'condition_rules' => null,
+                'sort_order' => 80,
             ],
         ]);
 
@@ -98,6 +119,9 @@ class CustomPropertySeeder extends Seeder
                 'show_on_invoice' => 1,
                 'allowed_values' => json_encode(array_values(array_slice(config('app.countries', []), 1))),
                 'validation' => 'string|max:255',
+                'condition_mode' => 'none',
+                'condition_rules' => null,
+                'sort_order' => 30,
             ],
         ]);
     }

--- a/themes/default/views/components/form/properties.blade.php
+++ b/themes/default/views/components/form/properties.blade.php
@@ -1,43 +1,80 @@
 @props(['properties', 'custom_properties' => []])
 
 @foreach ($custom_properties as $property)
-    @switch($property->type)
-        @case('date')
-        @case('string')
+    @php($wireKey = 'custom-property-' . ($property->id ?? $property->key))
+    @php($allowedValues = is_array($property->allowed_values) ? $property->allowed_values : [])
 
-        @case('number')
-            <x-form.input :type="$property->type" name="properties.{{ $property->key }}" :label="$property->name" :required="$property->required"
-                wire:model="properties.{{ $property->key }}" :value="$properties[$property->key] ?? ''" :disabled="$property->non_editable && isset($properties[$property->key])" />
-        @break
+    <div wire:key="{{ $wireKey }}">
+        @switch($property->type)
+            @case('date')
+            @case('string')
+            @case('number')
+                <x-form.input
+                    :type="$property->type"
+                    name="properties.{{ $property->key }}"
+                    :label="$property->name"
+                    :required="$property->required"
+                    wire:model.live="properties.{{ $property->key }}"
+                    :value="$properties[$property->key] ?? ''"
+                    :disabled="$property->non_editable && isset($properties[$property->key])"
+                />
+            @break
 
-        @case('checkbox')
-            <x-form.checkbox name="properties.{{ $property->key }}" :label="$property->name" :required="$property->required"
-                wire:model="properties.{{ $property->key }}" :checked="$properties[$property->key] ?? false" :disabled="$property->non_editable && isset($properties[$property->key])" />
-        @break
+            @case('checkbox')
+                <x-form.checkbox
+                    name="properties.{{ $property->key }}"
+                    :label="$property->name"
+                    :required="$property->required"
+                    wire:model.live="properties.{{ $property->key }}"
+                    :checked="$properties[$property->key] ?? false"
+                    :disabled="$property->non_editable && isset($properties[$property->key])"
+                />
+            @break
 
-        @case('radio')
-            @foreach ($property->allowed_values as $value)
-                <div class="flex items-center">
-                    <input type="radio" value="{{ $value }}" name="properties.{{ $property->key }}" type="radio"
-                        @checked($properties[$property->key] === $value ?? false) label="{{ $value }}" @required($property->required)
-                        wire:model="properties.{{ $property->key }}" :disabled="$property->non_editable && isset($properties[$property->key])"
-                        class="form-radio size-4 text-primary rounded-full focus:ring-secondary hover:bg-secondary ring-offset-primary-800 focus:ring-2 bg-background-secondary border-neutral" />
-                    <label class="ml-2 text-sm text-primary-100"
-                        for="properties.{{ $property->key }}">{{ $value }}</label>
-                </div>
-            @endforeach
-        @break
+            @case('radio')
+                @foreach ($allowedValues as $value)
+                    @php($optionKey = $wireKey . '-' . md5((string) $value))
 
-        @case('select')
-            <x-form.select name="properties.{{ $property->key }}" :label="$property->name"
-                wire:model="properties.{{ $property->key }}" :required="$property->required" :options="$property->allowed_values" :selected="$properties[$property->key] ?? ''" :disabled="$property->non_editable && isset($properties[$property->key])" />
-        @break
+                    <div class="flex items-center" wire:key="{{ $optionKey }}">
+                        <input
+                            type="radio"
+                            value="{{ $value }}"
+                            name="properties.{{ $property->key }}"
+                            @checked(($properties[$property->key] ?? null) === $value)
+                            @required($property->required)
+                            wire:model.live="properties.{{ $property->key }}"
+                            :disabled="$property->non_editable && isset($properties[$property->key])"
+                            class="form-radio size-4 text-primary rounded-full focus:ring-secondary hover:bg-secondary ring-offset-primary-800 focus:ring-2 bg-background-secondary border-neutral"
+                        />
+                        <label class="ml-2 text-sm text-primary-100" for="properties.{{ $property->key }}">{{ $value }}</label>
+                    </div>
+                @endforeach
+            @break
 
-        @case('text')
-            <x-form.textarea :type="$property->type" name="properties.{{ $property->key }}" :label="$property->name" :required="$property->required"
-                wire:model="properties.{{ $property->key }}" :disabled="$property->non_editable && isset($properties[$property->key])">{{ $properties[$property->key] ?? '' }}</x-form.textarea>
-        @break
+            @case('select')
+                <x-form.select
+                    name="properties.{{ $property->key }}"
+                    :label="$property->name"
+                    wire:model.live="properties.{{ $property->key }}"
+                    :required="$property->required"
+                    :options="$allowedValues"
+                    :selected="$properties[$property->key] ?? ''"
+                    :disabled="$property->non_editable && isset($properties[$property->key])"
+                />
+            @break
 
-        @default
-    @endswitch
+            @case('text')
+                <x-form.textarea
+                    :type="$property->type"
+                    name="properties.{{ $property->key }}"
+                    :label="$property->name"
+                    :required="$property->required"
+                    wire:model.live="properties.{{ $property->key }}"
+                    :disabled="$property->non_editable && isset($properties[$property->key])"
+                >{{ $properties[$property->key] ?? '' }}</x-form.textarea>
+            @break
+
+            @default
+        @endswitch
+    </div>
 @endforeach


### PR DESCRIPTION
Add conditional visibility support for user custom properties, extending the custom_properties table with dedicated fields.
Evolve the Filament CRUD to create conditional rules with operators (equals, not_equals, in, not_in, filled, blank) and dynamically generated value pickers.
Improve property ordering: sort_order now auto-fills sequentially per model and the listing exposes move up/down actions.
Harden the default client theme so dynamic properties render gracefully even when option lists are empty, and to remain Livewire 3 compliant.
Technical highlights
Migration 2025_10_16_000010_add_condition_fields_to_custom_properties_table.php adds condition_mode, condition_rules, and sort_order while preserving compatibility with existing setups.
CustomPropertyResource (Filament)
Normalises allowed_values, requires them for select/radio, and handles sort_order fallbacks per model with sanitized integers.
Repeater conditions use cached option lookups to scale well even with many properties.
CustomProperty model
Normalises sort_order during creating/saving events and exposes nextSortOrderForModel() for reuse.
CustomPropertyVisibilityService
Resolves current values (from request/old input), evaluates conditions, and gracefully matches countries by code or name.
Default theme
properties.blade.php now guards against null option lists, preventing runtime errors.
Language and currency switch components wrap their markup in a root <div>, avoiding Livewire root-tag exceptions.
Testing / manual validation
php artisan migrate (or migrate:fresh --seed) to apply the new schema and seeds.
In the admin panel:
Create/edit select and radio properties; allowed_values must be provided.
Build conditional rules and confirm they filter correctly.
Create a property without sort_order to ensure it appends at the end; use Move up/down to reorder.
In the default theme:
Visit the customer registration/edit form and ensure properties render without errors, including conditional visibility.
Optional: run phpunit to verify no regressions elsewhere.