### PR TITLE
Fix: Allow Blade expressions in In-App URL field

### DIFF
--- a/app/Admin/Resources/NotificationTemplateResource.php
+++ b/app/Admin/Resources/NotificationTemplateResource.php
@@ -103,7 +103,6 @@ class NotificationTemplateResource extends Resource
                             ->columnSpanFull(),
                         TextInput::make('in_app_url')
                             ->label('In-App URL')
-                            ->url()
                             ->maxLength(255)
                             ->placeholder('{{ route("invoices.show", $invoice) }}')
                             ->hint('Supports dynamic variables like {{ route("invoices.show", $invoice) }}')


### PR DESCRIPTION
**Problem:**
When editing a Notification Template, the 'In-App URL' field incorrectly triggers a URL validation error upon saving. This occurs even when the field contains valid Blade expressions (e.g., `{{ route("services.show", $service) }}`), which are explicitly stated as supported in the field's hint. The current `->url()` validation does not recognize these dynamic expressions as valid URLs during the form submission.

**Solution:**
This PR removes the `->url()` validation from the `in_app_url` field within `App\Admin\Resources\NotificationTemplateResource.php`.

**Benefit:**
This change allows administrators to save notification templates with dynamic Blade expressions in the 'In-App URL' field without encountering validation errors, aligning the field's behavior with its intended functionality and hint.