### PR TITLE
Optimize Dockerfile for faster CI builds via layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,30 +3,37 @@
 FROM --platform=$TARGETOS/$TARGETARCH php:8.3-fpm-alpine AS final
 WORKDIR /app
 
-COPY . ./
 RUN apk add --no-cache --update ca-certificates dcron curl git supervisor tar unzip nginx libpng-dev libxml2-dev libzip-dev icu-dev autoconf make g++ gcc libc-dev linux-headers gmp-dev \
     && docker-php-ext-configure zip \
     && docker-php-ext-install bcmath gd pdo_mysql zip intl sockets gmp \
     && pecl install redis \
     && docker-php-ext-enable redis \
-    && apk del autoconf make g++ gcc libc-dev \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && cp .env.example .env \
-    && chmod 777 -R bootstrap storage/* \
-    && composer install --no-dev --optimize-autoloader \
-    && rm -rf .env bootstrap/cache/*.php \
-    && chown -R nginx:nginx .
+    && apk del autoconf make g++ gcc libc-dev
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-RUN rm /usr/local/etc/php-fpm.conf \
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --no-autoloader --no-scripts
+
+COPY . ./
+RUN composer install --no-dev --optimize-autoloader
+
+RUN cp .env.example .env \
+    && chmod 777 -R bootstrap storage/* \
+    && rm -rf .env bootstrap/cache/*.php \
+    && chown -R nginx:nginx . \
+    && rm /usr/local/etc/php-fpm.conf \
     && echo "* * * * * /usr/local/bin/php /app/artisan schedule:run >> /dev/null 2>&1" >> /var/spool/cron/crontabs/root \
     && mkdir -p /var/run/php /var/run/nginx
 
 FROM --platform=$TARGETOS/$TARGETARCH node:22-alpine AS build
 WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm install
+
 COPY . ./
 COPY --from=final /app/vendor /app/vendor
-RUN npm install \
-    && npm run build
+RUN npm run build
 
 # Switch back to the final stage
 FROM final AS production


### PR DESCRIPTION
This PR restructures the multi-stage `Dockerfile` to properly leverage layer caching, which will significantly speed up subsequent builds.

By reordering the steps, we now install system dependencies (`apk add`) and vendor dependencies (`composer install`, `npm install`) *before* copying the main application source code (`COPY . .`).

This ensures these expensive, time-consuming steps are cached. They will no longer re-run on every single code commit, only when the dependency files (like `composer.lock`) actually change.