### PR TITLE
feat: align form component labels above inputs

### DIFF
--- a/themes/default/views/components/form/input.blade.php
+++ b/themes/default/views/components/form/input.blade.php
@@ -1,15 +1,12 @@
 @props(['name', 'label' => null, 'required' => false, 'divClass' => null, 'class' => null,'placeholder' => null, 'id' => null, 'type' => null, 'hideRequiredIndicator' => false, 'dirty' => false])
-<fieldset class="flex flex-col relative mt-3 w-full {{ $divClass ?? '' }}">
+<fieldset class="flex flex-col mt-3 w-full {{ $divClass ?? '' }}">
     @if ($label)
-        <legend>
-            <label for="{{ $name }}"
-                class="text-sm text-primary-100 absolute -translate-y-1/2 start-1 ml-1 bg-background-secondary px-2 rounded-md">
-                {{ $label }}
-                @if ($required && !$hideRequiredIndicator)
-                    <span class="text-red-500">*</span>
-                @endif
-            </label>
-        </legend>
+        <label for="{{ $name }}" class="mb-1 text-sm text-primary-100">
+            {{ $label }}
+            @if ($required && !$hideRequiredIndicator)
+                <span class="text-red-500">*</span>
+            @endif
+        </label>
     @endif
     <input type="{{ $type ?? 'text' }}" id="{{ $id ?? $name }}" name="{{ $name }}"
         class="block w-full text-sm text-base bg-background-secondary border border-neutral rounded-md shadow-sm focus:outline-none transition-all duration-300 ease-in-out disabled:bg-background-secondary/50 disabled:cursor-not-allowed {{ $class ?? '' }} @if ($type !== 'color') px-2.5 py-2.5 @endif"

--- a/themes/default/views/components/form/select.blade.php
+++ b/themes/default/views/components/form/select.blade.php
@@ -8,17 +8,14 @@
 'divClass' => null,
 'hideRequiredIndicator' => false,
 ])
-<fieldset class="flex flex-col relative mt-3 w-full {{ $divClass ?? '' }}">
+<fieldset class="flex flex-col mt-3 w-full {{ $divClass ?? '' }}">
     @if ($label)
-    <legend>
-        <label for="{{ $name }}"
-            class="text-sm text-primary-100 absolute -translate-y-1/2 start-1 ml-1 bg-background-secondary rounded-md px-2">
-            {{ $label }}
-            @if ($required && !$hideRequiredIndicator)
-            <span class="text-red-500">*</span>
-            @endif
-        </label>
-    </legend>
+    <label for="{{ $name }}" class="mb-1 text-sm text-primary-100">
+        {{ $label }}
+        @if ($required && !$hideRequiredIndicator)
+        <span class="text-red-500">*</span>
+        @endif
+    </label>
     @endif
 
     <select id="{{ $id ?? $name }}" {{ $multiple ? 'multiple' : '' }} {{ $attributes->except(['options', 'id', 'name', 'multiple', 'class']) }}

--- a/themes/default/views/components/form/textarea.blade.php
+++ b/themes/default/views/components/form/textarea.blade.php
@@ -10,17 +10,14 @@
 'hideRequiredIndicator' => false,
 'dirty' => false,
 ])
-<fieldset class="flex flex-col relative mt-3 w-full {{ $divClass ?? '' }}">
+<fieldset class="flex flex-col mt-3 w-full {{ $divClass ?? '' }}">
     @if ($label)
-    <legend>
-        <label for="{{ $name }}"
-            class="text-sm text-primary-100 absolute -translate-y-1/2 start-1 ml-1 bg-primary-800 px-2 rounded-md">
-            {{ $label }}
-            @if ($required && !$hideRequiredIndicator)
-            <span class="text-red-500">*</span>
-            @endif
-        </label>
-    </legend>
+    <label for="{{ $name }}" class="mb-1 text-sm text-primary-100">
+        {{ $label }}
+        @if ($required && !$hideRequiredIndicator)
+        <span class="text-red-500">*</span>
+        @endif
+    </label>
     @endif
     <textarea type="{{ $type ?? 'text' }}" id="{{ $id ?? $name }}" name="{{ $name }}"
         class="block w-full text-sm text-primary-100 bg-primary-800 border-2 border-neutral rounded-md outline-none focus:outline-none focus:border-secondary transition-all duration-300 ease-in-out disabled:bg-primary-700 disabled:cursor-not-allowed {{ $class ?? '' }} @if ($type !== 'color') px-2.5 py-2.5 @endif"


### PR DESCRIPTION
The label being placed over the inputs with a border & background are killing me. These simple changes give all labels a much cleaner look and feel more native to Paymenter.

<img width="937" height="507" alt="Screenshot (8)" src="https://github.com/user-attachments/assets/3a13c9b9-326f-44e4-8232-dfa28ea13a9e" />
<img width="982" height="501" alt="Screenshot (5)" src="https://github.com/user-attachments/assets/c1626189-3401-4d63-90b5-cac9be9653f0" />
<img width="1446" height="652" alt="Screenshot (7)" src="https://github.com/user-attachments/assets/7c242fd7-8735-4980-9bfb-3f9eb4bd0af7" />
<img width="1522" height="736" alt="Screenshot (6)" src="https://github.com/user-attachments/assets/1050b7bf-54f6-4971-a1b3-5e19d563936b" />
