### PR TITLE
Fix: Link recurring services to billing agreement during checkout

### DIFF
--- a/app/Livewire/Invoices/Show.php
+++ b/app/Livewire/Invoices/Show.php
@@ -104,14 +104,15 @@ class Show extends Component
         }
 
         if ($this->setAsDefault) {
-            $services = $this->recurringServices()->get();
+            $invoiceItems = $this->recurringServices()->get();
             $agreement = Auth::user()->billingAgreements()->where('ulid', $this->selectedMethod)->first();
 
-            foreach ($services as $service) {
+            foreach ($invoiceItems as $invoiceItem) {
+                $service = $invoiceItem->reference;
                 $service->update(['billing_agreement_id' => $agreement->id]);
             }
 
-            if ($services->count() > 0) {
+            if ($invoiceItems->count() > 0) {
                 $this->notify('Default payment method has been updated for recurring services.', 'success');
             }
         }

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -36,6 +36,7 @@ class Service extends Model implements Auditable
         'coupon_id',
         'user_id',
         'currency_code',
+        'billing_agreement_id',
     ];
 
     protected $casts = [


### PR DESCRIPTION
### Description

This PR addresses an issue where, during checkout, if a user selected an existing payment method and checked "Use for Recurring Payments," the associated services were not correctly updated with the `billing_agreement_id`. Consequently, the "Auto paying using" field for these services remained unset.

### Root Cause

The `recurringServices()` computed property in `app/Livewire/Invoices/Show.php` correctly identifies `InvoiceItem`s that reference recurring `Service`s. However, the subsequent `foreach` loop was iterating over these `InvoiceItem` objects, and attempting to update them as if they were `Service` objects. This led to either:
1. A silent failure (if `InvoiceItem` did not have `billing_agreement_id` in `$fillable` or the column didn't exist).
2. A `Column not found` SQL error when attempting to directly assign and save, as `invoice_items` table does not have a `billing_agreement_id` column.

### Solution

The fix modifies the `foreach` loop in `app/Livewire/Invoices/Show.php` to correctly access the underlying `Service` model from each `InvoiceItem`'s `reference` relationship. This ensures that the `billing_agreement_id` is updated on the actual `Service` model, as intended.