### PR TITLE
Update navigation to check user authentication (prevents 500's)

### DIFF
--- a/app/Classes/Navigation.php
+++ b/app/Classes/Navigation.php
@@ -71,7 +71,7 @@ class Navigation
                     'name' => __('navigation.admin'),
                     'url' => route('filament.admin.pages.dashboard'),
                     'spa' => false,
-                    'condition' => Auth::user()->role_id !== null,
+                    'condition' => Auth::check() && Auth::user()->role_id !== null,
                 ],
             ];
 


### PR DESCRIPTION
Currently with some pages if the user tries to access them while being fully un-authenticated (logged out or new user) the page returns a 500 instead. This prevents this by performing an Auth::check() first!