### PR TITLE
fix(docker): Prevent settings reset on container restart

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -58,7 +58,16 @@ chown -R nginx:nginx /app/storage
 
 ## make sure the db is set up
 echo -e "Migrating and Seeding D.B"
-php artisan migrate --seed --force
+php artisan migrate --force
+
+# Check if settings table is empty. If so, seed the database.
+SETTING_COUNT=$(php artisan tinker --execute='echo \App\Models\Setting::count()')
+if [ "$SETTING_COUNT" -eq 0 ]; then
+    echo "Database is empty. Seeding initial data..."
+    php artisan db:seed --force
+else
+    echo "Database already contains data. Skipping seeding."
+fi
 
 ## start cronjobs for the queue
 echo -e "Starting cron jobs."


### PR DESCRIPTION
This PR fixes an issue where user settings were reset to default on every container restart.

The `entrypoint.sh` script was running `php artisan migrate --seed` on every startup. This has been changed to a conditional seed: the database is now only seeded if the `settings` table is empty. This ensures data is only seeded on the first run, preserving user configurations on subsequent restarts.