### PR TITLE
Fix: Prevent duplicate execution of scheduled tasks

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -7,9 +7,9 @@ use App\Console\Commands\ScheduleHeartbeatCommand;
 use App\Console\Commands\TelemetryCommand;
 use Illuminate\Support\Facades\Schedule;
 
-Schedule::command(ScheduleHeartbeatCommand::class)->description('Updates the last scheduler run time')->everyMinute();
-Schedule::command(CronJob::class)->description('Runs daily to send out invoices, suspend servers, etc.')->dailyAt(config('settings.cronjob_time', '00:00'));
-Schedule::command(FetchEmails::class)->description('Import ticket emails using IMAP')->everyFiveMinutes()->withoutOverlapping();
+Schedule::command(ScheduleHeartbeatCommand::class)->description('Updates the last scheduler run time')->everyMinute()->onOneServer();
+Schedule::command(CronJob::class)->description('Runs daily to send out invoices, suspend servers, etc.')->dailyAt(config('settings.cronjob_time', '00:00'))->onOneServer();
+Schedule::command(FetchEmails::class)->description('Import ticket emails using IMAP')->everyFiveMinutes()->withoutOverlapping()->onOneServer();
 
 if (config('app.telemetry_enabled')) {
     $settings = Settings::getTelemetry();


### PR DESCRIPTION
This PR adds ->onOneServer() to the core scheduled tasks (ScheduleHeartbeatCommand, CronJob, FetchEmails) to prevent them from running on multiple servers simultaneously in a load-balanced environment.

This is crucial to avoid race conditions and duplicate actions, such as sending multiple invoices or fetching the same support emails, ensuring the application runs reliably when scaled horizontally.