### PR TITLE
Fix: Always send notifications for service changes

### DIFF
--- a/app/Jobs/Server/CreateJob.php
+++ b/app/Jobs/Server/CreateJob.php
@@ -35,12 +35,13 @@ class CreateJob implements ShouldQueue
             $data = ExtensionHelper::createServer($this->service);
         } catch (Exception $e) {
             if ($e->getMessage() == 'No server assigned to this product') {
-                return;
+                // return;
+            } else {
+                throw $e;
             }
-            throw $e;
         }
 
-        if ($this->sendNotification && isset($data)) {
+        if ($this->sendNotification) {
             NotificationHelper::serverCreatedNotification($this->service->user, $this->service, is_array($data) ? $data : []);
         }
     }

--- a/app/Jobs/Server/SuspendJob.php
+++ b/app/Jobs/Server/SuspendJob.php
@@ -34,12 +34,13 @@ class SuspendJob implements ShouldQueue
             $data = ExtensionHelper::suspendServer($this->service);
         } catch (Exception $e) {
             if ($e->getMessage() == 'No server assigned to this product') {
-                return;
+                // return;
+            } else {
+                throw $e;
             }
-            throw $e;
         }
 
-        if ($this->sendNotification && isset($data)) {
+        if ($this->sendNotification) {
             NotificationHelper::serverSuspendedNotification($this->service->user, $this->service, is_array($data) ? $data : []);
         }
     }

--- a/app/Jobs/Server/TerminateJob.php
+++ b/app/Jobs/Server/TerminateJob.php
@@ -34,12 +34,13 @@ class TerminateJob implements ShouldQueue
             $data = ExtensionHelper::terminateServer($this->service);
         } catch (Exception $e) {
             if ($e->getMessage() == 'No server assigned to this product') {
-                return;
+                // return;
+            } else {
+                throw $e;
             }
-            throw $e;
         }
 
-        if ($this->sendNotification && isset($data)) {
+        if ($this->sendNotification) {
             NotificationHelper::serverTerminatedNotification($this->service->user, $this->service, is_array($data) ? $data : []);
         }
     }


### PR DESCRIPTION
This change ensures that notifications for service creation, suspension, and termination are always sent, even if the product associated with the user's service does not have a server assigned.

Previously, if a product had no server, the relevant jobs would exit silently, and the user would not receive any notification. This was particularly confusing when the system terminated a service, as the user would expect to receive a confirmation.