### PR TITLE
Fix: Improve button alignment on homepage

### DIFF
--- a/extensions/Others/Announcements/resources/views/index.blade.php
+++ b/extensions/Others/Announcements/resources/views/index.blade.php
@@ -6,12 +6,12 @@
 
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             @foreach($announcements as $announcement)
-            <div class="bg-background-secondary hover:bg-background-secondary/80 border border-neutral p-4 rounded-lg">
+            <div class="flex flex-col bg-background-secondary hover:bg-background-secondary/80 border border-neutral p-4 rounded-lg">
                 <h2 class="text-xl font-bold">{{ $announcement->title }}</h2>
                 <div class="my-2 text-sm text-base/70">
                     {{ $announcement->description }}
                 </div>
-                <a href="{{ route('announcements.show', $announcement) }}" wire:navigate>
+                <a href="{{ route('announcements.show', $announcement) }}" wire:navigate class="mt-auto pt-2">
                     <x-button.primary>
                         {{ __('common.button.view') }}
                     </x-button.primary>

--- a/themes/default/views/home.blade.php
+++ b/themes/default/views/home.blade.php
@@ -37,7 +37,7 @@
                         {!! $category->description !!}
                     </article>
                     @endif
-                    <a href="{{ route('category.show', ['category' => $category->slug]) }}" wire:navigate class="mt-2">
+                    <a href="{{ route('category.show', ['category' => $category->slug]) }}" wire:navigate class="mt-auto pt-2">
                         <x-button.primary>
                             {{ __('common.button.view_all') }}
                             <x-ri-arrow-right-fill class="size-5" />


### PR DESCRIPTION
This PR addresses a minor UI issue on the homepage where buttons in the "Product Categories" and "Announcements" sections are misaligned. This is caused by varying content lengths, which results in cards of different heights.

By applying flexbox utilities (`mt-auto`), this change ensures that the action buttons are always aligned to the bottom of their respective cards. This creates a cleaner and more visually consistent layout.