### PR TITLE
feat: Allow Users to Cancel Pending Orders and Services

### DIFF
--- a/app/Livewire/Services/Show.php
+++ b/app/Livewire/Services/Show.php
@@ -56,6 +56,28 @@ class Show extends Component
         }
     }
 
+    public function cancelPendingService()
+    {
+        $this->authorize('update', $this->service);
+
+        if ($this->service->status !== Service::STATUS_PENDING) {
+            return;
+        }
+
+        $product = $this->service->product;
+        if ($product && !is_null($product->stock)) {
+            $product->increment('stock', $this->service->quantity);
+        }
+
+        $this->service->invoices()->where('status', 'pending')->update(['status' => 'cancelled']);
+
+        $this->service->update(['status' => 'cancelled']);
+
+        $this->notify(__('services.statuses.cancelled'), 'success', true);
+
+        return $this->redirect(route('services'), true);
+    }
+
     public function updatedShowBillingAgreement()
     {
         $this->selectedMethod = Auth::user()->billingAgreements()->where('id', $this->service->billing_agreement_id)?->first()?->ulid;

--- a/themes/default/views/invoices/show.blade.php
+++ b/themes/default/views/invoices/show.blade.php
@@ -65,11 +65,18 @@
                         <span class="text-yellow-500">{{ __('invoices.payment_pending') }}</span>
                         @endif
                     </div>
-                    <x-button.primary wire:click="$set('showPayModal', true)" class="mt-2" wire:loading.attr="disabled"
-                        wire:target="$set('showPayModal')">
-                        <span wire:loading wire:target="pay">Processing...</span>
-                        <span wire:loading.remove wire:target="pay">Pay</span>
-                    </x-button.primary>
+                    <div class="flex items-center justify-center gap-4 mt-2">
+                        <x-button.primary wire:click="$set('showPayModal', true)" class="mt-2" wire:loading.attr="disabled"
+                            wire:target="$set('showPayModal')">
+                            <span wire:loading wire:target="pay">Processing...</span>
+                            <span wire:loading.remove wire:target="pay">Pay</span>
+                        </x-button.primary>
+                        @if ($this->isCancellable())
+                            <x-button.danger wire:confirm="Are you sure?" class="mt-2" wire:click="cancelOrder">
+                                {{ __('services.cancel') }}
+                            </x-button.danger>
+                        @endif
+                    </div>
                     @endif
                     @endif
                 </div>

--- a/themes/default/views/services/show.blade.php
+++ b/themes/default/views/services/show.blade.php
@@ -69,25 +69,31 @@
             <div>
                 <h4 class="text-lg font-semibold">{{ __('services.actions') }}:</h4>
                 <div class="mt-2 flex flex-row gap-2 flex-wrap">
-                    @if($service->upgradable)
-                    <a href="{{ route('services.upgrade', $service->id) }}">
-                        <x-button.primary class="h-fit !w-fit">
+                    @if($service->status == 'pending')
+                        <x-button.danger class="h-fit !w-fit" wire:confirm="Are you sure?" wire:click="cancelPendingService">
+                            <span>{{ __('services.cancel') }}</span>
+                        </x-button.danger>
+                    @else
+                        @if($service->upgradable)
+                        <a href="{{ route('services.upgrade', $service->id) }}">
+                            <x-button.primary class="h-fit !w-fit">
+                                <span>{{ __('services.upgrade') }}</span>
+                            </x-button.primary>
+                        </a>
+                        @endif
+                        @if($service->upgrade()->where('status', 'pending')->exists())
+                        <x-button.primary class="h-fit !w-fit"
+                            @click="Alpine.store('notifications').addNotification([{message: '{{ __('services.upgrade_pending') }}', type: 'error'}])">
                             <span>{{ __('services.upgrade') }}</span>
                         </x-button.primary>
-                    </a>
-                    @endif
-                    @if($service->upgrade()->where('status', 'pending')->exists())
-                    <x-button.primary class="h-fit !w-fit"
-                        @click="Alpine.store('notifications').addNotification([{message: '{{ __('services.upgrade_pending') }}', type: 'error'}])">
-                        <span>{{ __('services.upgrade') }}</span>
-                    </x-button.primary>
-                    @endif
-                    @if($service->cancellable)
-                    <x-button.danger class="h-fit !w-fit" wire:click="$set('showCancel', true)">
-                        <span wire:loading.remove wire:target="$set('showCancel', true)">{{ __('services.cancel')
-                            }}</span>
-                        <x-loading target="$set('showCancel', true)" />
-                    </x-button.danger>
+                        @endif
+                        @if($service->cancellable)
+                        <x-button.danger class="h-fit !w-fit" wire:click="$set('showCancel', true)">
+                            <span wire:loading.remove wire:target="$set('showCancel', true)">{{ __('services.cancel')
+                                }}</span>
+                            <x-loading target="$set('showCancel', true)" />
+                        </x-button.danger>
+                        @endif
                     @endif
                     @if($showCancel)
                     <x-modal open="true"


### PR DESCRIPTION
This PR introduces a new feature allowing customers to cancel pending services and their associated invoices directly from the client area. This enhances user autonomy and ensures accurate stock management.

### Key Changes:

- Cancel from Service Page: A "Cancel" button is now available on the service details page if the service's status is `pending`.

- Cancel from Invoice Page: A "Cancel" button is added to the invoice page for `pending` invoices, visible only if all associated services are also `pending`.

- Backend Logic:

  - Implemented `cancelPendingService()` in `Show.php` to handle individual service cancellations.

  -  Implemented `cancelOrder()` and a corresponding `isCancellable()` check in `Show.php` for cancelling from the invoice.

- Stock Restoration: The logic ensures that when a service is cancelled, the stock for the corresponding product is incremented, preventing inventory discrepancies from abandoned orders.

### Motivation:

Currently, customers cannot cancel an order they've made but haven't paid for. This can lead to support requests for simple cancellations and can cause product stock to be reserved unnecessarily. This feature empowers users and automates the process, improving efficiency for both customers and administrators.