### PR TITLE
Feat: Add Contextual 'Create Ticket' Buttons for Users and Services

### DIFF
--- a/app/Admin/Resources/ServiceResource/Pages/EditService.php
+++ b/app/Admin/Resources/ServiceResource/Pages/EditService.php
@@ -14,6 +14,7 @@ use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
+use App\Admin\Resources\TicketResource;
 
 class EditService extends EditRecord
 {
@@ -22,6 +23,13 @@ class EditService extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('create_ticket')
+                ->label(__('ticket.create_ticket'))
+                ->color('gray')
+                ->url(fn () => TicketResource::getUrl('create', [
+                    'ownerRecord' => $this->record->user_id,
+                    'service_id' => $this->record->id,
+                ])),
             DeleteAction::make()
                 ->form(function (DeleteAction $action) {
                     $status = !in_array($this->record->status, [Service::STATUS_PENDING, Service::STATUS_CANCELLED]) && $this->record->product->server_id !== null;

--- a/app/Admin/Resources/TicketResource/Pages/CreateTicket.php
+++ b/app/Admin/Resources/TicketResource/Pages/CreateTicket.php
@@ -11,6 +11,23 @@ class CreateTicket extends CreateRecord
 {
     protected static string $resource = TicketResource::class;
 
+    public function mount(): void
+    {
+        parent::mount();
+
+        $data = [];
+        if ($userId = request()->get('ownerRecord')) {
+            $data['user_id'] = $userId;
+        }
+        if ($serviceId = request()->get('service_id')) {
+            $data['service_id'] = $serviceId;
+        }
+
+        if (!empty($data)) {
+            $this->form->fill($data);
+        }
+    }
+
     protected function handleRecordCreation(array $data): Model
     {
         $record = static::getModel()::create($data);

--- a/app/Admin/Resources/UserResource/Pages/ShowTickets.php
+++ b/app/Admin/Resources/UserResource/Pages/ShowTickets.php
@@ -7,6 +7,8 @@ use App\Models\Ticket;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use App\Admin\Resources\TicketResource;
+use Filament\Actions\Action;
 
 class ShowTickets extends ManageRelatedRecords
 {
@@ -19,6 +21,15 @@ class ShowTickets extends ManageRelatedRecords
     public static function getNavigationLabel(): string
     {
         return 'Tickets';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('create_ticket')
+                ->label(__('ticket.create_ticket'))
+                ->url(fn () => TicketResource::getUrl('create', ['ownerRecord' => $this->record])),
+        ];
     }
 
     public function table(Table $table): Table


### PR DESCRIPTION
### Summary

This PR streamlines the ticket creation process for administrators by adding convenient "Create Ticket" shortcuts to the User and Service management pages. These new buttons also serve as a reliable alternative to the often buggy user search on the main ticket creation page.

### The Problem

Currently, when an administrator needs to create a ticket, they must use the global "Create Ticket" button on the main ticket list page. This workflow has two significant issues:

1.  **Inefficient Process:** It requires manually searching for the user and/or the related service.
2.  **Unreliable Search:** More importantly, the user search functionality on that page is often unreliable, frequently failing to find existing users even when the correct name is entered. This can be a frustrating blocker.

### The Solution

This feature introduces two new contextual buttons that completely bypass these problems:

1.  **On the "Manage User Tickets" Page:** A "Create Ticket" button has been added. Clicking it opens the new ticket form with the current user **automatically selected**.
2.  **On the "Edit Service" Page:** A "Create Ticket" button has been added. Clicking it opens the new ticket form with both the service's owner (user) and the service itself **automatically selected**.

These changes not only make the process faster and more intuitive but also more reliable by pre-filling the correct data, avoiding the problematic search functionality entirely.