### PR TITLE
Feature: Add Filters to Admin Services List

### DIFF
--- a/app/Admin/Resources/ServiceResource.php
+++ b/app/Admin/Resources/ServiceResource.php
@@ -29,6 +29,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\RawJs;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\Filter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -220,6 +221,33 @@ class ServiceResource extends Resource
                         'suspended' => 'Suspended',
                         'cancelled' => 'Cancelled',
                     ]),
+                SelectFilter::make('user')
+                    ->label('User')
+                    ->relationship('user', 'id')
+                    ->getOptionLabelFromRecordUsing(fn ($record) => $record->name . ' (' . $record->email . ')')
+                    ->searchable()
+                    ->preload(),
+                SelectFilter::make('product')
+                    ->label('Product')
+                    ->relationship('product', 'name')
+                    ->searchable()
+                    ->preload(),
+                Filter::make('expires_at')
+                    ->form([
+                        DatePicker::make('expires_from')->label('Expires From'),
+                        DatePicker::make('expires_until')->label('Expires Until'),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query
+                            ->when(
+                                $data['expires_from'],
+                                fn (Builder $query, $date): Builder => $query->whereDate('expires_at', '>=', $date),
+                            )
+                            ->when(
+                                $data['expires_until'],
+                                fn (Builder $query, $date): Builder => $query->whereDate('expires_at', '<=', $date),
+                            );
+                    }),
             ])
             ->defaultSort(function (Builder $query): Builder {
                 return $query


### PR DESCRIPTION
Adds the ability to filter the services list in the admin panel by user, product, and expiration date.This PR adds filtering capabilities to the Services list in the admin panel.

Administrators can now filter services by:
- User
- Product
- Expiration date (date range)

This improves usability by making it easier to find and manage specific services.