### PR TITLE
Fix Coupon code 500 error when applying twice

### DIFF
--- a/app/Livewire/Cart.php
+++ b/app/Livewire/Cart.php
@@ -81,7 +81,7 @@ class Cart extends Component
     public function removeCoupon()
     {
         if (!ClassesCart::get()->coupon_id) {
-            return $this->notify('No coupon code applied', 'error');
+            return $this->notify('Coupon code could not be applied', 'error');
         }
         ClassesCart::removeCoupon();
         $this->refreshCouponState();


### PR DESCRIPTION
Currently when applying a coupon the page is not immediately reloaded causing confusion on if the code is applied. This allows the user to submit the same coupon again returning a 500 error code. This fixes that as well as reloading the view immediately and clearing up some error messages to be more clear.