### PR TITLE
Credit Refund behavior fix

### DIFF
--- a/app/Models/ServiceUpgrade.php
+++ b/app/Models/ServiceUpgrade.php
@@ -116,6 +116,7 @@ class ServiceUpgrade extends Model implements Auditable
         }
 
         $price = $oldItem->price(
+            null,
             $this->service->plan->billing_period,
             $this->service->plan->billing_unit,
             $this->service->currency_code


### PR DESCRIPTION
When a client orders a service with a coupon code the credit is refunded based off the base service price, not the price they actually paid.

The file was reformatted in the process to perform actions as early as possible making sure there are no additional calls to the database when not needed. 