### PR TITLE
Fix coupon recurring condition check

### DIFF
--- a/app/Livewire/Cart.php
+++ b/app/Livewire/Cart.php
@@ -163,7 +163,7 @@ class Cart extends Component
             // Create the services
             foreach ($cart->items as $item) {
                 // Is it a lifetime coupon, then we can adjust the price of the service
-                if ($this->coupon && ($this->coupon?->recurring === null || (int) $this->coupon?->recurring == 1)) {
+                if ($this->coupon && ($this->coupon->recurring === null || (int) $this->coupon->recurring == 1)) {
                     // Apply coupon only to first billing cycle (use original price for recurring)
                     $price = $item->price->original_price;
                 } else {


### PR DESCRIPTION
the value of (0) to make a coupon recurring forever is being evaluated as truthy by the empty function. 

This is resolved here using null instead for empty with the ? operator format. 

Not working
https://github.com/user-attachments/assets/6857c451-7eb9-4a24-9e5f-7d4bddeb8997

Working
https://github.com/user-attachments/assets/b24931b3-dd28-4af5-be26-ee9655fb1036


