### PR TITLE
Fix type error in Invoice route binding

### DIFF
--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -181,8 +181,14 @@ class Invoice extends Model implements Auditable
             return $this->where($field, $value)->firstOrFail();
         }
 
-        return $this->where('number', $value)
-            ->orWhere('id', $value)
-            ->firstOrFail();
+        // Try to find by number first
+        $query = $this->where('number', $value);
+
+        // Only try to match by ID if value is numeric
+        if (is_numeric($value)) {
+            $query->orWhere('id', $value);
+        }
+
+        return $query->firstOrFail();
     }
 }


### PR DESCRIPTION
## Problem

  Accessing invoices by invoice number (e.g., `/invoices/INV-2025726`) fails with:
  SQLSTATE[22P02]: invalid input syntax for type bigint: "INV-2025726"

  `resolveRouteBinding()` tries to match non-numeric values against the BIGINT `id` column, causing a type error.

  ## Solution

  Only attempt ID matching when the value is numeric:

  ```php
  $query = $this->where('number', $value);

  if (is_numeric($value)) {
      $query->orWhere('id', $value);
  }
