### PR TITLE
Fix Permissions Count Issue

### DIFF
--- a/app/Admin/Resources/RoleResource.php
+++ b/app/Admin/Resources/RoleResource.php
@@ -55,7 +55,6 @@ class RoleResource extends Resource
         return $table
             ->columns([
                 TextColumn::make('name')->sortable(),
-                // Show a single permissions summary (either 'All' or the count).
                 TextColumn::make('permissions_count')
                     ->label('permissions')
                     ->getStateUsing(fn (Role $record): string => in_array('*', $record->permissions) ? 'All' : (string) count($record->permissions))


### PR DESCRIPTION
This addition changes the RoleResource.php under /app/Admin/Resources to correctly display the count of permissions, instead of displaying the count [count] times.