### PR TITLE
fix: key specified without key length when seeding mysql

### DIFF
--- a/database/migrations/2024_02_15_122225_create_settings_table.php
+++ b/database/migrations/2024_02_15_122225_create_settings_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('settings', function (Blueprint $table) {
             $table->id();
-            $table->string('key', 255);
+            $table->string('key');
             $table->text('value')->nullable();
             $table->string('type')->default('string');
             $table->boolean('encrypted')->default(false);


### PR DESCRIPTION
When seeding a MySQL 9.4.2 db the following is observed in docker logs:

```
paymenter-1 | 2024_02_15_122225_create_settings_table ....................... 19.11ms FAIL 
paymenter-1 | 
paymenter-1 | In Connection.php line 824: 
paymenter-1 | 
paymenter-1 | SQLSTATE[42000]: Syntax error or access violation: 1170 BLOB/TEXT column 'k 
paymenter-1 | ey' used in key specification without a key length (Connection: mysql, SQL: 
paymenter-1 | alter table settings add unique settings_key_settingable_id_settingable 
paymenter-1 | _type_unique(key, settingable_id, settingable_type)) 
paymenter-1 | 
paymenter-1 | 
paymenter-1 | In Connection.php line 570: 
paymenter-1 | 
paymenter-1 | SQLSTATE[42000]: Syntax error or access violation: 1170 BLOB/TEXT column 'k 
paymenter-1 | ey' used in key specification without a key length
```

The proposed change fixes this issue during a first time seed of a mysql db by specifying a key length for 'key'.