### PR TITLE
Fix: Support HTML email replies in ticket

### DIFF
--- a/database/migrations/2025_08_02_150516_create_ticket_mail_logs_table.php
+++ b/database/migrations/2025_08_02_150516_create_ticket_mail_logs_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->string('subject');
             $table->string('from');
             $table->string('to');
-            $table->text('body');
+            $table->text('body')->nullable();
             $table->string('status');
             $table->timestamps();
         });

--- a/database/migrations/2025_11_14_212530_modify_ticket_mail_logs_body_nullable.php
+++ b/database/migrations/2025_11_14_212530_modify_ticket_mail_logs_body_nullable.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ticket_mail_logs', function (Blueprint $table) {
+            $table->text('body')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ticket_mail_logs', function (Blueprint $table) {
+            $table->text('body')->nullable(false)->change();
+        });
+    }
+};


### PR DESCRIPTION
 ## Problem
  `FetchEmails` command fails with database error when processing HTML-only emails:
  SQLSTATE[23502]: Not null violation: null value in column "body"

  ## Solution
  - Make `ticket_mail_logs.body` nullable
  - Add `getEmailBody()` helper to extract content from both text and HTML emails
  - Add validation to skip empty emails
  - Strip HTML tags and use `EmailReplyParser` to remove quoted content

  ## Changes
  - `app/Console/Commands/FetchEmails.php`: Enhanced email body extraction
  - Database migrations: Make body column nullable