### PR TITLE
Remove backticks from Invoice query for better compatibility

### DIFF
--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -189,6 +189,6 @@ class Invoice extends Model implements Auditable
             $query->orWhere('id', $value);
         }
 
-        return $query->orderByRaw('(`number` = ?) DESC', [$value])->firstOrFail();
+        return $query->orderByRaw('(number = ?) DESC', [$value])->firstOrFail();
     }
 }


### PR DESCRIPTION
## Description
  Removes MySQL-specific backticks from the Invoice model query.

## Benefits

- Standard SQL syntax
