### PR TITLE
Add support for environment variable overrides

### DIFF
--- a/extensions/Servers/Pterodactyl/Pterodactyl.php
+++ b/extensions/Servers/Pterodactyl/Pterodactyl.php
@@ -267,7 +267,7 @@ class Pterodactyl extends Server
             $environment[$variable['attributes']['env_variable']] = $settings[$variable['attributes']['env_variable']] ?? $variable['attributes']['default_value'];
         }
 
-        // allow for evnronment variable overrides from product settings
+        // allow for environment variable overrides from product settings
         // these would be set in the product configuration as ENV_VARIABLE_NAME
         // eg: SERVER_JARFILE => custom.jar
         foreach ($settings as $key => $value) {


### PR DESCRIPTION
* Added logic to scan `$settings` for keys starting with `ENV_`, strip the prefix, and set the corresponding environment variable in the `$environment` array, allowing overrides for server environment variables.