### PR TITLE
fix(security): prevent session hijacking and ticket rate limit DoS

### DIFF
--- a/app/Livewire/Client/Security.php
+++ b/app/Livewire/Client/Security.php
@@ -108,6 +108,12 @@ class Security extends Component
 
     public function logoutSession(Session $session)
     {
+        if ($session->user_id !== Auth::id()) {
+            $this->notify(__('Unauthorized'), 'error');
+
+            return;
+        }
+
         $session->delete();
 
         $this->notify(__('account.notifications.session_logged_out'));

--- a/app/Livewire/Tickets/Create.php
+++ b/app/Livewire/Tickets/Create.php
@@ -41,13 +41,14 @@ class Create extends Component
             'attachments.*' => 'file|max:10240',
         ]);
 
-        if (RateLimiter::tooManyAttempts('create-ticket', 1)) {
-            $this->notify('Too many ticket creation attempts. Please try again in 60 seconds.', 'error');
+        $rateLimitKey = 'create-ticket:' . Auth::id();
+        if (RateLimiter::tooManyAttempts($rateLimitKey, 1)) {
+            $this->notify('Too many ticket creation attempts. Please try again in 30 seconds.', 'error');
 
             return;
         }
 
-        RateLimiter::increment('create-ticket', 30);
+        RateLimiter::increment($rateLimitKey, 30);
 
         $ticket = Ticket::create([
             'user_id' => Auth::id(),


### PR DESCRIPTION
## Summary
  - Verify session ownership before logout to prevent users from terminating other users' sessions
  - Use per-user rate limit key for ticket creation to prevent global denial of service

## Changes
  - `app/Livewire/Client/Security.php`: Add `user_id` check before deleting session
  - `app/Livewire/Tickets/Create.php`: Change rate limit key from `create-ticket` to `create-ticket:{user_id}`