### PR TITLE
fix(checkout): Display recurring pricing for all products with defined setup fees 

### DIFF
--- a/themes/default/views/products/checkout.blade.php
+++ b/themes/default/views/products/checkout.blade.php
@@ -92,7 +92,7 @@
         <div class="text-lg font-semibold flex justify-between">
             <h4>{{ __('product.total_today') }}:</h4> {{ $total }}
         </div>
-        @if ($total->setup_fee && $plan->type == 'recurring')
+        @if (($total->setup_fee === "0.00" || $total->setup_fee === 0.0 || $total->setup_fee > 0) && $plan->type == 'recurring')
             <div class="text- font-semibold flex justify-between ">
                 <h4>{{ __('product.then_after_x', ['time' => $plan->billing_period . ' ' . trans_choice(__('services.billing_cycles.' . $plan->billing_unit), $plan->billing_period)]) }}:
                 </h4> {{ $total->format($total->price) }}


### PR DESCRIPTION
## Summary
This PR fixes inconsistent display of the "Then after" pricing line on product checkout page. The line now correctly appears for all recurring products with explicitly set setup fees (including $0.00), regardless of whether a server extension is configured. 

**Yes this is a long PR for a 1 line change, but this bug is a little nuanced and I wanted to dump all of my notes regarding this bug in case someone finds anything else here useful.** 

## Problem
Products were inconsistently showing the "Then after X period: $Y.YY" pricing line:
- Products WITHOUT server extensions + setup_fee explicitly set as 0.00 → **Showed correctly**
- Products WITH server extensions + setup_fee = 0.00 → **Did not show**
- Products with setup_fee > 0 → **Showed correctly**
- Products with setup_fee = NULL → **Correctly hidden**

## Root Cause
The issue stemmed from two interconnected problems:

### 1. Database Structure
Setup fees are stored in the `prices` table:
- `setup_fee = NULL` → **No setup fee defined**
- `setup_fee = 0.00` → **Explicitly set to zero (should show "Then after" line)**
- `setup_fee > 0` → **Has a setup fee (should show "Then after" line)**

### 2. Type Inconsistency in Price Object
The `App\Classes\Price` object returns `setup_fee` with different types depending on server extension presence:

**Products WITH server extensions:**
```php
+price: 14.99        // float
+setup_fee: 0.0      // float
```

**Products WITHOUT server extensions:**
```php
+price: "5.99"       // string
+setup_fee: "0.00"   // string
```

### 3. Original Buggy Condition
```php
@if ($total->setup_fee && $plan->type == 'recurring')
```

This failed because:
- PHP's truthy check treats both `0.0` (float) and `"0.00"` (string) as falsy
- Even though `setup_fee` was explicitly set to 0.00 in the database, the condition evaluated to `false`

## Solution
Updated the condition to explicitly check for all valid setup fee representations:

**File:** `themes/default/views/products/checkout.blade.php`

**Before:**
```php
@if ($total->setup_fee && $plan->type == 'recurring')
```

**After:**
```php
@if (($total->setup_fee === "0.00" || $total->setup_fee === 0.0 || $total->setup_fee > 0) && $plan->type == 'recurring')
```

This now correctly identifies when a setup fee has been explicitly set by checking:
- String "0.00" (products without server extensions)
- Float 0.0 (products with server extensions)
- Any value > 0 (both types)

Products with `setup_fee = NULL` in the database result in `setup_fee = 0` (integer) in the Price object, which correctly fails all three checks and hides the "Then after" line.

## Testing Performed

**Database verification:**
```sql
SELECT 
    p.id, p.name, pl.type, pr.setup_fee, pr.setup_fee IS NULL as is_null
FROM products p
JOIN plans pl ON pl.priceable_id = p.id
JOIN prices pr ON pr.plan_id = pl.id
WHERE p.id IN (6, 17);
```

Results showed:
- Product 6 (has server): `setup_fee = 0.00`
- Product 17 (no server): `setup_fee = 0.00`
- Other products: `setup_fee = NULL`

**Verified now that:**
- Products with server extension: Shows "Then after" line
- Products without server: Show "Then after" line
- Products with NULL setup_fee: Do not show "Then after" line
- Products with setup_fee > 0: Show "Then after" line with setup fee note
- One-time and free products: Correctly excluded
- Products with pricing intervals that don't have set up fees with others that do display correctly

## Note for Future Consideration
Consider standardizing the Price object to always return consistent types (either all floats or all strings) to prevent similar type-related bugs in the future. The current implementation appears to be influenced by whether a server extension is configured, which creates an unexpected dependency.