### PR TITLE
Add cached view paths to Tailwind v4 source configuration

### DIFF
--- a/themes/default/css/app.css
+++ b/themes/default/css/app.css
@@ -8,21 +8,26 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Application Views */
 @source "../views";
+/* Paymenter / Filament / Custom Extensions */
 @source "../../../extensions/**/*.blade.php";
-@source "../../../extensions/Servers/Proxmox";
-@source "../../../extensions/Others/Pages";
+/* Cached views (required when using `php artisan view:cache`) */
+@source "../../../storage/framework/views/*.php";
 
 @theme {
   /* Font Family */
   --font-sans: "Nunito", ui-sans-serif, system-ui, sans-serif;
 
   --animate-wiggle: wiggle 1s ease-in-out infinite;
+
   @keyframes wiggle {
+
     0%,
     100% {
       transform: rotate(-20deg);
     }
+
     50% {
       transform: rotate(20deg);
     }
@@ -33,22 +38,22 @@
   /* Branding Colors */
   --color-primary: hsl(var(--color-primary));
   --color-secondary: hsl(var(--color-secondary));
-  
+
   /* Neutral Colors */
   --color-neutral: hsl(var(--color-neutral));
-  
+
   /* Text Colors */
   --color-base: hsl(var(--color-base));
   --color-muted: hsl(var(--color-muted));
   --color-inverted: hsl(var(--color-inverted));
-  
+
   /* State Colors */
   --color-success: hsl(var(--color-success));
   --color-error: hsl(var(--color-error));
   --color-warning: hsl(var(--color-warning));
   --color-inactive: hsl(var(--color-inactive));
   --color-info: hsl(var(--color-info));
-  
+
   /* Background Colors */
   --color-background: hsl(var(--color-background));
   --color-background-secondary: hsl(var(--color-background-secondary));
@@ -63,6 +68,7 @@ If we ever want to remove these styles, we need to add an explicit border
 color utility to any element that depends on these defaults.
 */
 @layer base {
+
   *,
   ::after,
   ::before,
@@ -87,36 +93,36 @@ color utility to any element that depends on these defaults.
 @import './easymde.css';
 
 ::-webkit-scrollbar {
-    background: transparent;
-    width: 12px;
-    height: 12px;
+  background: transparent;
+  width: 12px;
+  height: 12px;
 }
 
 ::-webkit-scrollbar-thumb {
-    border: solid 0 rgb(0 0 0 / 0%);
-    border-right-width: 4px;
-    border-left-width: 4px;
-    -webkit-border-radius: 9px 4px;
-    -webkit-box-shadow: inset 0 0 0 1px hsl(var(--color-primary)), inset 0 0 0 4px hsl(var(--color-primary));
+  border: solid 0 rgb(0 0 0 / 0%);
+  border-right-width: 4px;
+  border-left-width: 4px;
+  -webkit-border-radius: 9px 4px;
+  -webkit-box-shadow: inset 0 0 0 1px hsl(var(--color-primary)), inset 0 0 0 4px hsl(var(--color-primary));
 }
 
 ::-webkit-scrollbar-track {
-    background: transparent;
+  background: transparent;
 }
 
 ::-webkit-scrollbar-track-piece {
-    background: transparent;
-    margin: 4px 0;
+  background: transparent;
+  margin: 4px 0;
 }
 
 ::-webkit-scrollbar-thumb:horizontal {
-    border-right-width: 0;
-    border-left-width: 0;
-    border-top-width: 4px;
-    border-bottom-width: 4px;
-    -webkit-border-radius: 4px 9px;
+  border-right-width: 0;
+  border-left-width: 0;
+  border-top-width: 4px;
+  border-bottom-width: 4px;
+  -webkit-border-radius: 4px 9px;
 }
 
 ::-webkit-scrollbar-corner {
-    background: transparent;
+  background: transparent;
 }


### PR DESCRIPTION
# Add cached view paths to Tailwind v4 source configuration

This PR updates the Tailwind v4 `@source` configuration to ensure that all Tailwind classes used in production are correctly detected during the Vite build process.

## Background

While working with custom Paymenter extensions, I noticed that Tailwind did not recognize certain classes during the production build, even after adding my own plugins. The classes were present in the Blade templates, but Tailwind v4 only scans the files explicitly listed in the `@source` directives.

During debugging, I found that the compiled (cached) views inside `storage/framework/views` *did* contain the correct classes, and Tailwind successfully detected them when these files were included in the scan paths. Since we use `php artisan view:cache` in our deployment process, these cached views represent the actual templates used in production.

## What this PR does

- Adds `@source "../../../storage/framework/views/*.php";`  
  → Ensures Tailwind scans Laravel’s compiled view files generated by `php artisan view:cache`.
- Removes redundant extension paths already covered by the wildcard pattern.
- Keeps the Tailwind configuration clean, minimal, and production‑safe.

## Why this is needed

Including cached views ensures that Tailwind correctly detects all classes that appear in production, preventing missing styles and UI inconsistencies. This is especially important in setups that rely on view caching, Filament, or custom Paymenter extensions.

## Notes

I am open to alternative solutions or improvements, but this is the most reliable approach I have found so far to ensure consistent Tailwind output during the Vite build process.
