### PR TITLE
fix: adding missing commas to default theme

### DIFF
--- a/themes/default/theme.php
+++ b/themes/default/theme.php
@@ -74,7 +74,7 @@ return [
             'name' => 'muted',
             'label' => 'Muted - Text Color (Light)',
             'type' => 'color',
-            'default' => 'hsl(220 0% 53%)',
+            'default' => 'hsl(220, 0%, 53%)',
         ],
         [
             'name' => 'inverted',


### PR DESCRIPTION
Missing commas from a default value from the default theme.
Without commas, invalid value error is thrown upon first save of the default theme. 