### PR TITLE
Fix: Setting type casting broken due to switch fall-through in Retrieved/Saving events

### DIFF
--- a/app/Events/Setting/Retrieved.php
+++ b/app/Events/Setting/Retrieved.php
@@ -30,12 +30,16 @@ class Retrieved
         switch ($setting->type) {
             case 'boolean':
                 $setting->value = (bool) $setting->value;
+                break;
             case 'integer':
                 $setting->value = (int) $setting->value;
+                break;
             case 'float':
                 $setting->value = (float) $setting->value;
+                break;
             case 'array':
                 $setting->value = json_decode($setting->value, true);
+                break;
             default:
                 return;
         }

--- a/app/Events/Setting/Saving.php
+++ b/app/Events/Setting/Saving.php
@@ -33,10 +33,13 @@ class Saving
         switch ($setting->type) {
             case 'boolean':
                 $setting->value = (bool) $setting->value;
+                break;
             case 'integer':
                 $setting->value = (int) $setting->value;
+                break;
             case 'float':
                 $setting->value = (float) $setting->value;
+                break;
             case 'array':
                 if (!is_string($setting->value) || is_null(json_decode($setting->value))) {
                     $setting->value = json_encode($setting->value);


### PR DESCRIPTION
## Summary

- The `switch` statements in `App\Events\Setting\Retrieved` and `App\Events\Setting\Saving`
  are missing `break` statements, causing all non-default cases to fall through.
- For example, a `boolean` setting would be cast to `bool`, then to `int`, then to `float`,
  then finally passed to `json_decode()` — producing incorrect values.
  
## Impact

All settings of type `boolean`, `integer`, and `float` stored in the database are being
read/written with incorrect values, which silently corrupts the settings data.

## Fix
- Added missing `break` in `Retrieved.php` and `Saving.php`.

