### PR TITLE
Fix: Remove dd() from production code in Setting Retrieved/Saving events

### DIFF
--- a/app/Events/Setting/Retrieved.php
+++ b/app/Events/Setting/Retrieved.php
@@ -22,8 +22,8 @@ class Retrieved
             try {
                 $setting->value = Crypt::decryptString($setting->value);
             } catch (Throwable $th) {
-                // Normal `throw new Exception($th)` wasn't working here, so we are using dump-and-die for now.
-                dd($th, $setting->value);
+                report($th);
+                $setting->value = null;
             }
         }
 

--- a/app/Events/Setting/Saving.php
+++ b/app/Events/Setting/Saving.php
@@ -22,8 +22,8 @@ class Saving
             try {
                 $setting->value = Crypt::encryptString($setting->value);
             } catch (Throwable $th) {
-                // Normal `throw new Exception($th)` wasn't working here, so we are using dump-and-die for now.
-                dd($th, $setting->value);
+                report($th);
+                throw $th;
             }
 
             // An encrypted value can only be a string, so we refrain from converting its type


### PR DESCRIPTION
## Summary

- `App\Events\Setting\Retrieved` and `App\Events\Setting\Saving` use `dd()` in their
  catch blocks when encryption/decryption fails.
- In production, this immediately kills the application and dumps potentially sensitive
  encrypted values to the response body.

## Impact

If any encrypted setting fails to decrypt (e.g. after an APP_KEY rotation), the entire
application crashes with a raw dump visible to end users.

## Fix

- Replaced with `report()` for logging. In `Retrieved`, the value is gracefully set to
  `null`; in `Saving`, the exception is re-thrown to prevent saving corrupted data.