### PR TITLE
Fix: Registration form does not validate CAPTCHA despite importing Captchable trait

### DIFF
--- a/app/Livewire/Auth/Register.php
+++ b/app/Livewire/Auth/Register.php
@@ -49,6 +49,8 @@ class Register extends ComponentWithProperties
 
     public function submit()
     {
+        $this->captcha();
+        
         $validatedData = $this->validate();
 
         $user = User::create([


### PR DESCRIPTION
## Summary

- `App\Livewire\Auth\Register` uses the `Captchable` trait but never calls
  `$this->captcha()` in its `submit()` method.
- This means bots can register unlimited accounts even when CAPTCHA is enabled
  in the admin settings.

## Impact

When CAPTCHA is enabled, it is only enforced on the login form but not on
registration, leaving registration wide open to automated abuse.

## Fix

- Added the missing `$this->captcha()` call before `$this->validate()`,
  matching the pattern used in `App\Livewire\Auth\Login`.