### PR TITLE
Fix: Captchable trait fires validation on every property change, not just captcha

### DIFF
--- a/app/Traits/Captchable.php
+++ b/app/Traits/Captchable.php
@@ -11,7 +11,7 @@ trait Captchable
 
     private $is_valid = false;
 
-    public function updated()
+    public function updatedCaptcha()
     {
         $this->captcha();
     }
@@ -64,8 +64,6 @@ trait Captchable
         }
 
         throw ValidationException::withMessages(['captcha' => 'The CAPTCHA was invalid.']);
-
-        return $this->is_valid = false;
     }
 
     // Google Recaptcha
@@ -82,8 +80,6 @@ trait Captchable
         }
 
         throw ValidationException::withMessages(['captcha' => 'The CAPTCHA was invalid.']);
-
-        return $this->is_valid = false;
     }
 
     // hCaptcha
@@ -100,7 +96,5 @@ trait Captchable
         }
 
         throw ValidationException::withMessages(['captcha' => 'The CAPTCHA was invalid.']);
-
-        return $this->is_valid = false;
     }
 }


### PR DESCRIPTION
## Summary

- The `Captchable` trait defines `updated()` which is a Livewire lifecycle hook
  triggered on *any* public property change (email, password, name, etc.).
- This causes captcha validation to fire on every keystroke in all forms that use
  the trait (Login, Register, VerifyEmail, Password Reset/Request), resulting in
  "CAPTCHA is required" errors appearing while the user is still filling out the form.

## Impact

Users experience constant validation errors and unnecessary captcha API calls
while typing in any form field on Login, Register, and Password Reset pages.

## Fix

- Renamed to `updatedCaptcha()` so it only fires when the `$captcha` property
  changes (i.e. when the captcha widget returns a token).
- Also removed three unreachable `return` statements after `throw` in the
  `turnstile()`, `recaptcha()`, and `hcaptcha()` methods.