### PR TITLE
fix: limit convoy server name length to 40 characters

### DIFF
--- a/extensions/Servers/Convoy/Convoy.php
+++ b/extensions/Servers/Convoy/Convoy.php
@@ -258,7 +258,7 @@ class Convoy extends Server
         $data = [
             'node_id' => (int) $node,
             'user_id' => $user['id'],
-            'name' => $hostname . ' ' . $service->user->name,
+            'name' => Str::substr($hostname . ' ' . $service->user->name, 0, 40), # The server name must not be greater than 40 characters
             'hostname' => $hostname,
             'vmid' => null,
             'limits' => [


### PR DESCRIPTION
This PR fixes the Convoy integration when hostname + user name is over 40 characters. 

The fix is very direct, but stops the integration failing.

The integration fails with this error before the fix: 

```
production.ERROR: The name must not be greater than 40 characters. {"exception":"[object] (Exception(code: 0): The name must not be greater than 40 characters. at /app/extensions/Servers/Convoy/Convoy.php:24)
```

The result after the fix is no error, but users with long name or long hostname will get a weird server-name 🤷 

