### PR TITLE
feat: Enhance Stripe customer creation

### DIFF
--- a/extensions/Gateways/Stripe/Stripe.php
+++ b/extensions/Gateways/Stripe/Stripe.php
@@ -177,18 +177,16 @@ class Stripe extends Gateway
             'metadata' => ['invoice_id' => $invoice->id],
         ];
 
-        // Always create/get a Stripe customer for authenticated users, use detailed info based on setting
-        if ($invoice->user) {
-            try {
-                $includeDetails = (bool) $this->config('stripe_create_customers');
-                $customer = $this->createOrGetStripeCustomer($invoice->user, $includeDetails);
-                if (!empty($customer->id)) {
-                    $intentData['customer'] = $customer->id;
-                }
-            } catch (Exception $e) {
-                // ignore customer creation errors and continue without customer
+        try {
+            $includeDetails = (bool) $this->config('stripe_create_customers');
+            $customer = $this->createOrGetStripeCustomer($invoice->user, $includeDetails);
+            if (!empty($customer->id)) {
+                $intentData['customer'] = $customer->id;
             }
+        } catch (Exception $e) {
+            // ignore customer creation errors and continue without customer
         }
+        
         $intent = $this->request('post', '/payment_intents', $intentData);
 
         // Pay the invoice using Stripe


### PR DESCRIPTION
## Enhance Stripe customer creation

- One-time payments now always create Stripe customers (previously only billing agreements did)
- Added "Create detailed Stripe customers" toggle to control detail level 
- When enabled: customers include address, phone, and company details 
- When disabled: customers include only name, email, and user ID 

**Why:**
- Improves payment tracking in Stripe Dashboard (no more "guest" payments)
- Allows the usage of tools like Stripe Radar to reduce fraud
- Toggle allows privacy-conscious merchants to limit stored data in Stripe