### PR TITLE
feat: add delete, delete all and mark as unread to in-app notifications

### DIFF
--- a/app/Livewire/Components/Notifications.php
+++ b/app/Livewire/Components/Notifications.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Components;
 
 use App\Livewire\Component;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 
@@ -37,6 +38,35 @@ class Notifications extends Component
         }
 
         $notification->markAsRead();
+        unset($this->notifications);
+    }
+
+    public function markAsUnread($id)
+    {
+        $notification = Auth::user()->notifications()->where('id', $id)->first();
+        if (!$notification) {
+            return;
+        }
+
+        DB::table('notifications')->where('id', $notification->id)->update(['read_at' => null]);
+        unset($this->notifications);
+    }
+
+    public function deleteNotification($id)
+    {
+        $notification = Auth::user()->notifications()->where('id', $id)->first();
+        if (!$notification) {
+            return;
+        }
+
+        $notification->delete();
+        unset($this->notifications);
+    }
+
+    public function deleteAllNotifications()
+    {
+        Auth::user()->notifications()->delete();
+        unset($this->notifications);
     }
 
     public function render()

--- a/themes/default/views/components/notifications.blade.php
+++ b/themes/default/views/components/notifications.blade.php
@@ -14,6 +14,15 @@
             </div>
         </x-slot:trigger>
         <x-slot:content>
+            @if($this->notifications->isNotEmpty())
+            <div class="flex items-center justify-between px-4 py-2 border-b border-neutral/50">
+                <span class="text-xs font-semibold text-base/60">{{ __('Notifications') }}</span>
+                <button wire:click="deleteAllNotifications" wire:confirm="{{ __('Delete all notifications?') }}"
+                    class="text-xs text-base/60 hover:text-red-500 transition-colors cursor-pointer" type="button">
+                    {{ __('Clear all') }}
+                </button>
+            </div>
+            @endif
             <div class="w-full max-h-96 overflow-y-auto">
                 @if ($this->notifications->isEmpty())
                 <div class="p-4 text-center text-sm text-base/80">
@@ -21,25 +30,33 @@
                 </div>
                 @else
                 @foreach ($this->notifications as $notification)
-                <div wire:click="goToNotification({{ $notification->id }})"
-                    class="block px-4 py-3 hover:bg-background-secondary/50 cursor-pointer @if (!$loop->last) border-b border-neutral/50 @endif">
+                <div class="block px-4 py-3 hover:bg-background-secondary/50 @if (!$loop->last) border-b border-neutral/50 @endif group">
                     <div class="flex items-start gap-3">
                         <x-ri-notification-3-fill
                             class="size-5 mt-1 flex-shrink-0 {{ $notification->read_at ? 'text-base/80' : 'text-primary' }}" />
-                        <div class="flex flex-col">
+                        <div class="flex flex-col flex-1 min-w-0 cursor-pointer" wire:click="goToNotification({{ $notification->id }})">
                             <span class="font-medium">{{ $notification->title }}</span>
                             <span class="text-sm text-base/80">{{ $notification->body }}</span>
                             <div class="flex flex-row justify-between mt-1 text-xs text-base/60">
                                 <p>
                                     {{ $notification->created_at->diffForHumans() }}
                                 </p>
-
-                                <button wire:click.stop="markAsRead({{ $notification->id }})" class="cursor-pointer"
-                                    type="button">
+                                @if($notification->read_at)
+                                <button wire:click.stop="markAsUnread({{ $notification->id }})" class="cursor-pointer" type="button">
+                                    {{ __('Mark as unread') }}
+                                </button>
+                                @else
+                                <button wire:click.stop="markAsRead({{ $notification->id }})" class="cursor-pointer" type="button">
                                     {{ __('Mark as read') }}
                                 </button>
+                                @endif
                             </div>
                         </div>
+                        <button wire:click.stop="deleteNotification({{ $notification->id }})"
+                            class="shrink-0 mt-1 size-5 rounded flex items-center justify-center text-base/40 opacity-0 group-hover:opacity-100 hover:text-red-500 transition-all cursor-pointer"
+                            title="{{ __('Delete') }}" type="button">
+                            <x-ri-close-line class="size-3.5" />
+                        </button>
                     </div>
                 </div>
                 @endforeach


### PR DESCRIPTION
Add deleteNotification(), deleteAllNotifications() and markAsUnread() methods to the Notifications Livewire component. Also invalidate the computed property cache after markAsRead() so the UI updates immediately.

Update the default theme to expose these actions: a delete button appears on each notification row on hover, a 'Clear all' button with confirmation in the panel header, and a toggle between 'Mark as read' and 'Mark as unread'.