### PR TITLE
feat/invoice-enhancements

### DIFF
--- a/app/Admin/Resources/CouponResource.php
+++ b/app/Admin/Resources/CouponResource.php
@@ -14,6 +14,7 @@ use Filament\Actions\EditAction;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
@@ -104,6 +105,21 @@ class CouponResource extends Resource
                 DatePicker::make('expires_at')
                     ->label('Expires At'),
 
+                Toggle::make('apply_after_tax')
+                    ->label(__('admin.coupon.apply_after_tax'))
+                    ->helperText(__('admin.coupon.apply_after_tax_helper'))
+                    ->default(false)
+                    ->columnSpanFull(),
+
+                Select::make('role_id')
+                    ->label(__('admin.coupon.restrict_to_role'))
+                    ->relationship('role', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->nullable()
+                    ->placeholder(__('admin.coupon.restrict_to_role_placeholder'))
+                    ->helperText(__('admin.coupon.restrict_to_role_helper')),
+
                 Select::make('products')
                     ->label('Products')
                     ->relationship(
@@ -125,6 +141,7 @@ class CouponResource extends Resource
             ->columns([
                 TextColumn::make('code')->searchable(),
                 TextColumn::make('value')->searchable()->formatStateUsing(fn ($record) => $record->value . ($record->type === 'percentage' ? '%' : config('settings.default_currency'))),
+                TextColumn::make('role.name')->label(__('admin.coupon.restrict_to_role_column'))->placeholder(__('admin.coupon.restrict_to_role_public'))->sortable(),
             ])
             ->filters([
                 //

--- a/app/Admin/Resources/InvoiceResource.php
+++ b/app/Admin/Resources/InvoiceResource.php
@@ -8,6 +8,7 @@ use App\Admin\Resources\InvoiceResource\Pages\CreateInvoice;
 use App\Admin\Resources\InvoiceResource\Pages\EditInvoice;
 use App\Admin\Resources\InvoiceResource\Pages\ListInvoices;
 use App\Admin\Resources\InvoiceResource\RelationManagers\TransactionsRelationManager;
+use App\Models\Coupon;
 use App\Models\Currency;
 use App\Models\Invoice;
 use App\Models\Service;
@@ -18,18 +19,22 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Support\RawJs;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
 
 class InvoiceResource extends Resource
 {
@@ -89,6 +94,104 @@ class InvoiceResource extends Resource
                     ->label('Send Email')
                     ->hiddenOn('edit')
                     ->default(true),
+                Select::make('coupon_id')
+                    ->label(__('admin.invoice.coupon'))
+                    ->options(fn () => Coupon::query()->pluck('code', 'id'))
+                    ->searchable()
+                    ->preload()
+                    ->placeholder(__('admin.invoice.coupon_placeholder'))
+                    ->helperText(__('admin.invoice.coupon_helper'))
+                    ->dehydrated(false)
+                    ->live()
+                    ->afterStateUpdated(function ($state, Get $get, Set $set) {
+                        if (! $state) {
+                            return;
+                        }
+
+                        $coupon = Coupon::find($state);
+
+                        if (! $coupon) {
+                            return;
+                        }
+
+                        if ($coupon->expires_at?->isPast()) {
+                            Notification::make()
+                                ->title(__('admin.invoice.coupon_expired'))
+                                ->danger()
+                                ->send();
+                            $set('coupon_id', null);
+
+                            return;
+                        }
+
+                        if ($coupon->starts_at?->isFuture()) {
+                            Notification::make()
+                                ->title(__('admin.invoice.coupon_not_active'))
+                                ->danger()
+                                ->send();
+                            $set('coupon_id', null);
+
+                            return;
+                        }
+
+                        if ($coupon->max_uses && $coupon->services()->count() >= $coupon->max_uses) {
+                            Notification::make()
+                                ->title(__('admin.invoice.coupon_max_uses'))
+                                ->danger()
+                                ->send();
+                            $set('coupon_id', null);
+
+                            return;
+                        }
+
+                        $items = $get('items') ?? [];
+                        $subtotal = collect($items)
+                            ->filter(fn ($item) => floatval($item['price'] ?? 0) > 0 && ! ($item['apply_after_tax'] ?? false))
+                            ->sum(fn ($item) => floatval($item['price']) * max(1, intval($item['quantity'] ?? 1)));
+
+                        if ($subtotal <= 0) {
+                            Notification::make()
+                                ->title(__('admin.invoice.coupon_no_items'))
+                                ->warning()
+                                ->send();
+                            $set('coupon_id', null);
+
+                            return;
+                        }
+
+                        $discount = $coupon->calculateDiscount($subtotal);
+
+                        if ($discount <= 0) {
+                            Notification::make()
+                                ->title(__('admin.invoice.coupon_no_discount'))
+                                ->danger()
+                                ->send();
+                            $set('coupon_id', null);
+
+                            return;
+                        }
+
+                        $label = $coupon->type === 'percentage'
+                            ? $coupon->code . ' (-' . number_format($coupon->value, 2) . '%)'
+                            : $coupon->code;
+
+                        $items[(string) Str::uuid()] = [
+                            'price' => -round($discount, 2),
+                            'quantity' => 1,
+                            'description' => $label,
+                            'reference_type' => null,
+                            'reference_id' => null,
+                            'apply_after_tax' => $coupon->apply_after_tax,
+                        ];
+
+                        $set('items', $items);
+                        $set('coupon_id', null);
+
+                        Notification::make()
+                            ->title(__('admin.invoice.coupon_applied'))
+                            ->success()
+                            ->send();
+                    }),
                 Repeater::make('items')
                     ->relationship('items')
                     ->label('Items')
@@ -97,7 +200,6 @@ class InvoiceResource extends Resource
                     ->schema([
                         TextInput::make('price')
                             ->label('Price')
-                            // Grab invoice currency
                             ->prefix(fn (Get $get): ?string => Currency::where('code', $get('../../currency_code'))->first()?->prefix)
                             ->suffix(fn (Get $get): ?string => Currency::where('code', $get('../../currency_code'))->first()?->suffix)
                             ->required()
@@ -113,20 +215,35 @@ class InvoiceResource extends Resource
                             ->required()
                             ->numeric()
                             ->placeholder('Enter the quantity of the product'),
-                        TextInput::make('description')
+                        TextInput::make('unit')
+                            ->label(__('admin.invoice_item.unit'))
+                            ->nullable()
+                            ->placeholder(__('admin.invoice_item.unit_placeholder'))
+                            ->helperText(__('admin.invoice_item.unit_helper')),
+                        MarkdownEditor::make('description')
                             ->label('Description')
                             ->required()
+                            ->toolbarButtons([
+                                'bold',
+                                'bulletList',
+                                'italic',
+                                'link',
+                                'orderedList',
+                                'strike',
+                            ])
+                            ->columnSpanFull()
                             ->hintAction(
-                                Action::make('View Service')
+                                Action::make('viewService')
                                     ->url(function (Get $get) {
                                         return ServiceResource::getUrl('edit', ['record' => $get('reference_id')]);
                                     })
                                     ->label('View Service')
-                                    ->hidden(fn (Get $get): bool => !in_array($get('reference_type'), [Service::class, ServiceUpgrade::class]))
+                                    ->hidden(fn (Get $get): bool => ! in_array($get('reference_type'), [Service::class, ServiceUpgrade::class]))
                             )
                             ->placeholder('Enter the description of the product'),
                         Hidden::make('reference_type'),
                         Hidden::make('reference_id'),
+                        Hidden::make('apply_after_tax'),
                     ]),
 
             ]);
@@ -163,7 +280,7 @@ class InvoiceResource extends Resource
                     ->date()
                     ->searchable()
                     ->sortable(),
-                TextColumn::make('formattedTotal')
+                TextColumn::make('formattedGrandTotal')
                     ->label('Total'),
                 TextColumn::make('formattedRemaining')
                     ->label('Remaining'),
@@ -189,6 +306,11 @@ class InvoiceResource extends Resource
                     DeleteBulkAction::make(),
                 ]),
             ]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->with(['items', 'currency', 'transactions', 'snapshot', 'user']);
     }
 
     public static function getRelations(): array

--- a/app/Classes/Cart.php
+++ b/app/Classes/Cart.php
@@ -178,6 +178,10 @@ class Cart
             throw new DisplayException('Coupon code not found');
         }
 
+        if ($coupon->role_id && Auth::user()?->role_id !== $coupon->role_id) {
+            throw new DisplayException('Coupon code not found');
+        }
+
         if ($coupon->expires_at && $coupon->expires_at->isPast()) {
             throw new DisplayException('Coupon code has expired');
         }

--- a/app/Livewire/Components/LocaleSwitch.php
+++ b/app/Livewire/Components/LocaleSwitch.php
@@ -65,7 +65,7 @@ class LocaleSwitch extends Component
 
     public function render()
     {
-        $locales = config('settings.allowed_languages');
+        $locales = config('settings.allowed_languages', []);
 
         return view('components.locale-switch', compact('locales'));
     }

--- a/app/Livewire/Invoices/Index.php
+++ b/app/Livewire/Invoices/Index.php
@@ -13,7 +13,7 @@ class Index extends Component
     public function render()
     {
         return view('invoices.index', [
-            'invoices' => Auth::user()->invoices()->with(['user', 'snapshot', 'items'])->orderBy('id', 'desc')->paginate(config('settings.pagination')),
+            'invoices' => Auth::user()->invoices()->with(['user', 'snapshot', 'items', 'currency'])->orderBy('id', 'desc')->paginate(config('settings.pagination')),
         ])->layoutData([
             'title' => __('invoices.invoices'),
             'sidebar' => true,

--- a/app/Livewire/Invoices/Show.php
+++ b/app/Livewire/Invoices/Show.php
@@ -69,6 +69,22 @@ class Show extends Component
     }
 
     #[Computed]
+    public function hasPaymentOptions(): bool
+    {
+        if (count($this->gateways) > 0) {
+            return true;
+        }
+        if ($this->savedPaymentMethods->isNotEmpty()) {
+            return true;
+        }
+
+        return Auth::user()->credits()
+            ->where('currency_code', $this->invoice->currency_code)
+            ->where('amount', '>', 0)
+            ->exists();
+    }
+
+    #[Computed]
     public function recurringServices()
     {
         return $this->invoice->items()

--- a/app/Livewire/Invoices/Widget.php
+++ b/app/Livewire/Invoices/Widget.php
@@ -13,7 +13,7 @@ class Widget extends Component
     public function render()
     {
         return view('invoices.widget', [
-            'invoices' => Auth::user()->invoices()->orderBy('id', 'desc')->where('status', '=', 'pending')->paginate(config('settings.pagination')),
+            'invoices' => Auth::user()->invoices()->with('items', 'currency')->orderBy('id', 'desc')->where('status', '=', 'pending')->paginate(config('settings.pagination')),
         ])->layoutData([
             'title' => __('invoices.invoices'),
         ]);

--- a/app/Livewire/Services/Index.php
+++ b/app/Livewire/Services/Index.php
@@ -21,7 +21,7 @@ class Index extends Component
         }
 
         return view('services.index', [
-            'services' => $query->paginate(config('settings.pagination')),
+            'services' => $query->with(['product', 'plan'])->paginate(config('settings.pagination')),
         ])->layoutData([
             'title' => 'Services',
             'sidebar' => true,

--- a/app/Livewire/Services/Widget.php
+++ b/app/Livewire/Services/Widget.php
@@ -23,7 +23,7 @@ class Widget extends Component
         }
 
         return view('services.widget', [
-            'services' => $query->paginate(config('settings.pagination')),
+            'services' => $query->with(['product', 'plan'])->paginate(config('settings.pagination')),
         ])->layoutData([
             'title' => 'Services',
         ]);

--- a/app/Livewire/Tickets/Index.php
+++ b/app/Livewire/Tickets/Index.php
@@ -16,7 +16,7 @@ class Index extends Component
     public function render()
     {
         return view('tickets.index', [
-            'tickets' => Ticket::where('user_id', Auth::id())->latest()->paginate(config('settings.pagination')),
+            'tickets' => Ticket::where('user_id', Auth::id())->with('latestMessage')->latest()->paginate(config('settings.pagination')),
         ])->layoutData([
             'title' => 'Tickets',
             'sidebar' => true,

--- a/app/Livewire/Tickets/Widget.php
+++ b/app/Livewire/Tickets/Widget.php
@@ -14,7 +14,7 @@ class Widget extends Component
     public function render()
     {
         return view('tickets.widget', [
-            'tickets' => Ticket::where('user_id', Auth::id())->where('status', '!=', 'closed')->latest()->paginate(config('settings.pagination')),
+            'tickets' => Ticket::where('user_id', Auth::id())->where('status', '!=', 'closed')->with('latestMessage')->latest()->paginate(config('settings.pagination')),
         ])->layoutData([
             'title' => 'Tickets',
         ]);

--- a/app/Models/Coupon.php
+++ b/app/Models/Coupon.php
@@ -19,6 +19,8 @@ class Coupon extends Model implements Auditable
         'starts_at',
         'expires_at',
         'recurring',
+        'apply_after_tax',
+        'role_id',
     ];
 
     protected $casts = [
@@ -27,11 +29,17 @@ class Coupon extends Model implements Auditable
         'max_uses' => 'integer',
         'max_uses_per_user' => 'integer',
         'value' => 'float',
+        'apply_after_tax' => 'boolean',
     ];
 
     /**
      * Get the products that belong to the option.
      */
+    public function role()
+    {
+        return $this->belongsTo(Role::class);
+    }
+
     public function products()
     {
         return $this->belongsToMany(Product::class, 'coupon_products');

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -32,11 +32,6 @@ class Invoice extends Model implements Auditable
 
     public bool $send_create_email = true;
 
-    /**
-     * Total of the invoice.
-     *
-     * @return string
-     */
     public function total(): Attribute
     {
         return Attribute::make(
@@ -44,35 +39,62 @@ class Invoice extends Model implements Auditable
         );
     }
 
-    /**
-     * Total of the invoice.
-     *
-     * @return string
-     */
+    public function taxableTotal(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->items
+                ->filter(fn ($item) => ! $item->apply_after_tax)
+                ->sum(fn ($item) => $item->price * $item->quantity)
+        );
+    }
+
+    public function afterTaxTotal(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->items
+                ->filter(fn ($item) => $item->apply_after_tax)
+                ->sum(fn ($item) => $item->price * $item->quantity)
+        );
+    }
+
+    public function grandTotal(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => round((float) $this->formattedTotal->total + $this->afterTaxTotal, 2)
+        );
+    }
+
     public function formattedTotal(): Attribute
     {
         return Attribute::make(
-            get: fn () => new Price(['price' => $this->total, 'currency' => $this->currency, 'tax' => $this->tax])
+            get: fn () => new Price(
+                ['price' => $this->taxableTotal, 'currency' => $this->currency],
+                false,
+                false,
+                config('settings.tax_type', 'inclusive') === 'exclusive',
+                $this->tax
+            )
         );
     }
 
-    /**
-     * Formatted remaining amount of the invoice.
-     */
+    public function formattedGrandTotal(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->formattedTotal->format($this->grandTotal)
+        );
+    }
+
     public function formattedRemaining(): Attribute
     {
         return Attribute::make(
-            get: fn () => new Price(['price' => $this->remaining, 'currency' => $this->currency, 'tax' => $this->tax])
+            get: fn () => $this->formattedTotal->format($this->remaining)
         );
     }
 
-    /**
-     * Remaining amount of the invoice.
-     */
     public function remaining(): Attribute
     {
         return Attribute::make(
-            get: fn () => $this->total - $this->transactions->where('status', InvoiceTransactionStatus::Succeeded)->sum('amount')
+            get: fn () => round($this->grandTotal - $this->transactions->where('status', InvoiceTransactionStatus::Succeeded)->sum('amount'), 2)
         );
     }
 

--- a/app/Models/InvoiceItem.php
+++ b/app/Models/InvoiceItem.php
@@ -17,15 +17,18 @@ class InvoiceItem extends Model implements Auditable
     protected $fillable = [
         'invoice_id',
         'quantity',
+        'unit',
         'price',
         'description',
         'gateway_id',
         'reference_id',
         'reference_type',
+        'apply_after_tax',
     ];
 
     protected $casts = [
         'price' => 'decimal:2',
+        'apply_after_tax' => 'boolean',
     ];
 
     public function invoice()

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -42,4 +42,9 @@ class Ticket extends Model implements Auditable
     {
         return $this->hasMany(TicketMessage::class);
     }
+
+    public function latestMessage()
+    {
+        return $this->hasOne(TicketMessage::class)->latestOfMany();
+    }
 }

--- a/database/migrations/2026_04_19_000000_change_invoice_items_description_to_text.php
+++ b/database/migrations/2026_04_19_000000_change_invoice_items_description_to_text.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table->text('description')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table->string('description')->nullable()->change();
+        });
+    }
+};

--- a/database/migrations/2026_04_19_000001_add_apply_after_tax_to_coupons_and_invoice_items.php
+++ b/database/migrations/2026_04_19_000001_add_apply_after_tax_to_coupons_and_invoice_items.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('coupons', function (Blueprint $table) {
+            $table->boolean('apply_after_tax')->default(false)->after('recurring');
+        });
+
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table->boolean('apply_after_tax')->default(false)->after('reference_type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('coupons', function (Blueprint $table) {
+            $table->dropColumn('apply_after_tax');
+        });
+
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table->dropColumn('apply_after_tax');
+        });
+    }
+};

--- a/database/migrations/2026_04_20_000001_add_role_id_to_coupons.php
+++ b/database/migrations/2026_04_20_000001_add_role_id_to_coupons.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('coupons', function (Blueprint $table) {
+            $table->foreignId('role_id')->nullable()->constrained()->nullOnDelete()->after('apply_after_tax');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('coupons', function (Blueprint $table) {
+            $table->dropForeignIdFor(\App\Models\Role::class);
+            $table->dropColumn('role_id');
+        });
+    }
+};

--- a/database/migrations/2026_04_20_000002_add_unit_to_invoice_items.php
+++ b/database/migrations/2026_04_20_000002_add_unit_to_invoice_items.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table->string('unit')->nullable()->after('quantity');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table->dropColumn('unit');
+        });
+    }
+};

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -11,4 +11,32 @@ return [
         'tickets_closed' => 'Tickets closed',
         'email_logs_deleted' => 'Email logs deleted',
     ],
+
+    'coupon' => [
+        'restrict_to_role' => 'Restrict to Role',
+        'restrict_to_role_placeholder' => 'Public (any user can apply this coupon)',
+        'restrict_to_role_helper' => 'If set, only users with this role can apply the coupon. Leave empty for public coupons.',
+        'restrict_to_role_column' => 'Restricted To',
+        'restrict_to_role_public' => 'Public',
+        'apply_after_tax' => 'Apply After Tax',
+        'apply_after_tax_helper' => 'When enabled, this discount is subtracted after tax. The discount amount is still calculated on the pre-tax base.',
+    ],
+
+    'invoice' => [
+        'coupon' => 'Coupon',
+        'coupon_placeholder' => 'Select a coupon to apply a discount',
+        'coupon_helper' => 'Selecting a coupon appends a discount line item based on the current items total.',
+        'coupon_expired' => 'This coupon has expired.',
+        'coupon_not_active' => 'This coupon is not active yet.',
+        'coupon_max_uses' => 'This coupon has reached its maximum number of uses.',
+        'coupon_no_items' => 'Add at least one item before applying a coupon.',
+        'coupon_no_discount' => 'This coupon does not apply to the current items.',
+        'coupon_applied' => 'Coupon applied, a discount line item has been added.',
+    ],
+
+    'invoice_item' => [
+        'unit' => 'Unit',
+        'unit_placeholder' => 'e.g. hours, GB (leave empty for plain quantity)',
+        'unit_helper' => 'Optional label shown next to the quantity (e.g. "62 hours").',
+    ],
 ];

--- a/lang/en/invoices.php
+++ b/lang/en/invoices.php
@@ -10,6 +10,8 @@ return [
     'id' => 'ID',
     'total' => 'Total',
     'subtotal' => 'Subtotal',
+    'discount' => 'Discount',
+    'net' => 'Net',
     'invoice' => 'Invoice #:id',
     'proforma_invoice' => 'Proforma Invoice #:id',
     'unit_price' => 'Unit Price',
@@ -56,5 +58,6 @@ return [
     'apply_credits_and_continue' => 'Apply Credits and Continue',
     'apply_credits_and_pay' => 'Apply Credits and Pay',
     'amount_due' => 'Amount Due: :amount',
+    'more_items' => '+:count more item|+:count more items',
 
 ];

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -44,16 +44,8 @@
             text-align: right;
         }
 
-        table tr td {
-            padding: 0;
-        }
-
         table tr td:last-child {
             text-align: right;
-        }
-
-        .invoice-items tbody tr:first-child td {
-            padding-top: 10px;
         }
 
         .invoice-info {
@@ -62,6 +54,23 @@
 
         .invoice-info td {
             padding: 2px 0;
+        }
+
+        .invoice-items td {
+            padding: 10px 16px 10px 0;
+            border-bottom: 1px solid #eee;
+            vertical-align: top;
+        }
+
+        .invoice-items th {
+            padding-right: 16px;
+        }
+
+        .invoice-items th:last-child,
+        .invoice-items td:last-child {
+            padding-right: 0;
+            white-space: nowrap;
+            min-width: 70px;
         }
 
         .totals-section {
@@ -102,6 +111,25 @@
             font-weight: bold;
             color: #000;
         }
+
+        .invoice-items td p {
+            margin: 0 0 4px 0;
+            padding: 0;
+        }
+
+        .invoice-items td p:last-child {
+            margin-bottom: 0;
+        }
+
+        .invoice-items td ul,
+        .invoice-items td ol {
+            margin: 4px 0;
+            padding-left: 16px;
+        }
+
+        .invoice-items td.item-description {
+            font-size: 0.8em;
+        }
     </style>
 </head>
 
@@ -113,7 +141,6 @@
     </div>
     @endif
 
-    <!-- Invoice status -->
     <div style="margin-bottom: 20px;font-size: 20px">
         <strong>{{ __('invoices.status') }}:</strong><span
             style="@if($invoice->status == 'paid') color: green; @else color: orange; @endif">
@@ -141,54 +168,82 @@
     <p>{{ __('invoices.invoice_no') }}: <strong>{{ $invoice->number }}</strong></p>
     @endif
 
+    @php
+        $visibleItems = $invoice->items->filter(fn ($item) => $item->price >= 0);
+        $showQtyColumns = $visibleItems->some(fn ($i) => $i->quantity != 1 || !empty($i->unit));
+    @endphp
     <table style="margin-top: 40px;" class="invoice-items">
         <thead>
             <tr>
                 <th>{{ __('invoices.item') }}</th>
+                @if($showQtyColumns)
                 <th style="width: 100px">{{ __('invoices.quantity') }}</th>
                 <th>{{ __('invoices.unit_price') }}</th>
+                @endif
                 <th>{{ __('invoices.total') }}</th>
             </tr>
         </thead>
         <tbody>
-            @foreach($invoice->items as $item)
+            @foreach($visibleItems as $item)
+            @php
+                $descHtml = \Illuminate\Support\Str::markdown($item->description ?? '', ['html_input' => 'strip', 'renderer' => ['soft_break' => "<br>\n"]]);
+                $descHtml = trim(preg_replace('/<\/?p>/', '', $descHtml));
+                $descHtml = preg_replace('/(<br>\s*)+$/', '', $descHtml);
+            @endphp
             <tr>
-                <td>{{ $item->description }}</td>
-                <td>{{ $item->quantity }}</td>
+                <td class="item-description">{!! $descHtml !!}</td>
+                @if($showQtyColumns)
+                <td>{{ $item->quantity }}{{ $item->unit ? ' ' . $item->unit : '' }}</td>
                 <td>{{ $item->formattedPrice }}</td>
+                @endif
                 <td>{{ $item->formattedTotal }}</td>
             </tr>
             @endforeach
         </tbody>
     </table>
 
-    <!-- Totals Section -->
+    @php
+        $beforeTaxDiscountItems = $invoice->items->filter(fn ($i) => $i->price < 0 && ! $i->apply_after_tax);
+        $afterTaxDiscountItems = $invoice->items->filter(fn ($i) => $i->price < 0 && $i->apply_after_tax);
+        $positiveItemsTotal = $visibleItems->sum(fn ($i) => $i->price * $i->quantity);
+        $hasBeforeDiscount = $beforeTaxDiscountItems->isNotEmpty();
+        $hasTax = $invoice->formattedTotal->tax > 0;
+    @endphp
     <div class="totals-section">
-        @if ($invoice->formattedTotal->tax > 0)
         <table class="totals-table">
+            @if ($hasBeforeDiscount)
             <tr>
                 <td class="label">{{ __('invoices.subtotal') }}</td>
-                <td class="amount">{{ $invoice->formattedTotal->format($invoice->formattedTotal->price - $invoice->formattedTotal->tax) }}</td>
+                <td class="amount">{{ $invoice->formattedTotal->format($positiveItemsTotal) }}</td>
+            </tr>
+            @foreach ($beforeTaxDiscountItems as $discountItem)
+            <tr>
+                <td class="label">{{ $discountItem->description }}</td>
+                <td class="amount">{{ $discountItem->formattedTotal }}</td>
+            </tr>
+            @endforeach
+            @endif
+            @if ($hasTax)
+            <tr>
+                <td class="label">{{ $hasBeforeDiscount ? __('invoices.net') : __('invoices.subtotal') }}</td>
+                <td class="amount">{{ $invoice->formattedTotal->format($invoice->formattedTotal->subtotal) }}</td>
             </tr>
             <tr>
-                <td class="label">
-                    {{ $invoice->tax->name }} ({{ $invoice->tax->rate }}%)
-                </td>
+                <td class="label">{{ $invoice->tax->name }} ({{ $invoice->tax->rate }}%)</td>
                 <td class="amount">{{ $invoice->formattedTotal->formatted->tax }}</td>
             </tr>
+            @endif
+            @foreach ($afterTaxDiscountItems as $discountItem)
+            <tr>
+                <td class="label">{{ $discountItem->description }}</td>
+                <td class="amount">{{ $discountItem->formattedTotal }}</td>
+            </tr>
+            @endforeach
             <tr class="total-row">
                 <td class="label">{{ __('invoices.total') }}</td>
-                <td class="amount">{{ $invoice->formattedTotal }}</td>
+                <td class="amount">{{ $invoice->formattedGrandTotal }}</td>
             </tr>
         </table>
-        @else
-        <table class="totals-table">
-            <tr class="total-row">
-                <td class="label">{{ __('invoices.total') }}</td>
-                <td class="amount">{{ $invoice->formattedTotal }}</td>
-            </tr>
-        </table>
-        @endif
     </div>
 
     <div style="clear: both;"></div>

--- a/themes/default/views/components/entity-card.blade.php
+++ b/themes/default/views/components/entity-card.blade.php
@@ -1,0 +1,20 @@
+@props(['href', 'statusClass' => ''])
+
+<a href="{{ $href }}" wire:navigate>
+    <div class="bg-background-secondary hover:bg-background-secondary/80 border border-neutral p-4 rounded-lg mb-4">
+        <div class="flex items-center justify-between mb-2">
+            <div class="flex items-center gap-3">
+                <div class="bg-secondary/10 p-2 rounded-lg">
+                    {{ $icon }}
+                </div>
+                {{ $heading }}
+            </div>
+            <div class="size-5 rounded-md p-0.5 {{ $statusClass }}">
+                {{ $status }}
+            </div>
+        </div>
+        @if(!$detail->isEmpty())
+            {{ $detail }}
+        @endif
+    </div>
+</a>

--- a/themes/default/views/components/invoice-card.blade.php
+++ b/themes/default/views/components/invoice-card.blade.php
@@ -1,0 +1,47 @@
+@props(['invoice'])
+
+@php
+    $statusClass = match($invoice->status) {
+        'paid'      => 'text-success bg-success/20',
+        'cancelled' => 'text-info bg-info/20',
+        default     => 'text-warning bg-warning/20',
+    };
+
+    $visibleItems = $invoice->items->filter(fn($i) => $i->price >= 0);
+    $first        = $visibleItems->first();
+    $extraCount   = $visibleItems->count() - 1;
+    $plainDesc    = $first ? strip_tags(\Illuminate\Support\Str::markdown($first->description ?? '', ['html_input' => 'strip'])) : '';
+@endphp
+
+<x-entity-card :href="route('invoices.show', $invoice)" :statusClass="$statusClass">
+    <x-slot:icon><x-ri-bill-line class="size-5 text-secondary" /></x-slot:icon>
+
+    <x-slot:heading>
+        <span class="font-medium">
+            {{ !$invoice->number && config('settings.invoice_proforma', false)
+                ? __('invoices.proforma_invoice', ['id' => $invoice->id])
+                : __('invoices.invoice', ['id' => $invoice->number]) }}
+        </span>
+        <x-ri-circle-fill class="size-1 text-base/20" />
+        <span class="text-base text-sm">{{ $invoice->formattedGrandTotal }}</span>
+    </x-slot:heading>
+
+    <x-slot:status>
+        @if ($invoice->status == 'paid')
+            <x-ri-checkbox-circle-fill />
+        @elseif($invoice->status == 'cancelled')
+            <x-ri-forbid-fill />
+        @else
+            <x-ri-error-warning-fill />
+        @endif
+    </x-slot:status>
+
+    <x-slot:detail>
+        @if($first)
+            <p class="text-base/50 text-sm line-clamp-2 mt-1">{{ $plainDesc }}</p>
+            @if($extraCount > 0)
+                <p class="text-base/40 text-xs mt-0.5">{{ trans_choice(__('invoices.more_items'), $extraCount, ['count' => $extraCount]) }}</p>
+            @endif
+        @endif
+    </x-slot:detail>
+</x-entity-card>

--- a/themes/default/views/components/service-card.blade.php
+++ b/themes/default/views/components/service-card.blade.php
@@ -1,0 +1,47 @@
+@props(['service'])
+
+@php
+    $statusClass = match(true) {
+        $service->status === 'active'                                      => 'text-success bg-success/20',
+        in_array($service->status, ['suspended', 'cancelled'])             => 'text-inactive bg-inactive/20',
+        default                                                            => 'text-warning bg-warning/20',
+    };
+
+    $billingDetail = in_array($service->plan->type, ['recurring'])
+        ? __('services.every_period', [
+            'period' => $service->plan->billing_period > 1 ? $service->plan->billing_period : '',
+            'unit'   => trans_choice(__('services.billing_cycles.' . $service->plan->billing_unit), $service->plan->billing_period),
+        ])
+        : '';
+@endphp
+
+<x-entity-card :href="route('services.show', $service)" :statusClass="$statusClass">
+    <x-slot:icon><x-ri-instance-line class="size-5 text-secondary" /></x-slot:icon>
+
+    <x-slot:heading>
+        <span class="font-medium">{{ $service->label }}</span>
+    </x-slot:heading>
+
+    <x-slot:status>
+        @if ($service->status === 'active')
+            <x-ri-checkbox-circle-fill />
+        @elseif(in_array($service->status, ['suspended', 'cancelled']))
+            <x-ri-forbid-fill />
+        @else
+            <x-ri-error-warning-fill />
+        @endif
+    </x-slot:status>
+
+    <x-slot:detail>
+        <div class="text-base/50 text-sm flex gap-1">
+            {{ $billingDetail }}
+            @if($service->expires_at && $service->expires_at > now())
+                @if($billingDetail) - @endif
+                {{ __('services.renews_in') }}
+                <x-tooltip :message="$service->expires_at->format('M d, Y')">
+                    {{ $service->expires_at->longAbsoluteDiffForHumans() }}
+                </x-tooltip>
+            @endif
+        </div>
+    </x-slot:detail>
+</x-entity-card>

--- a/themes/default/views/components/ticket-card.blade.php
+++ b/themes/default/views/components/ticket-card.blade.php
@@ -1,0 +1,35 @@
+@props(['ticket'])
+
+@php
+    $statusClass = match($ticket->status) {
+        'open'   => 'text-success bg-success/20',
+        'closed' => 'text-inactive bg-inactive/20',
+        default  => 'text-info bg-info/20',
+    };
+@endphp
+
+<x-entity-card :href="route('tickets.show', $ticket)" :statusClass="$statusClass">
+    <x-slot:icon><x-ri-ticket-line class="size-5 text-secondary" /></x-slot:icon>
+
+    <x-slot:heading>
+        <span class="font-medium">#{{ $ticket->id }} - {{ $ticket->subject }}</span>
+    </x-slot:heading>
+
+    <x-slot:status>
+        @if ($ticket->status === 'open')
+            <x-ri-add-circle-fill />
+        @elseif($ticket->status === 'closed')
+            <x-ri-forbid-fill />
+        @else
+            <x-ri-chat-smile-2-fill />
+        @endif
+    </x-slot:status>
+
+    <x-slot:detail>
+        <p class="text-base/50 text-sm">
+            {{ __('ticket.last_activity') }}
+            {{ $ticket->latestMessage?->created_at->diffForHumans() }}
+            {{ $ticket->department ? ' - ' . $ticket->department : '' }}
+        </p>
+    </x-slot:detail>
+</x-entity-card>

--- a/themes/default/views/invoices/index.blade.php
+++ b/themes/default/views/invoices/index.blade.php
@@ -2,38 +2,7 @@
     <x-navigation.breadcrumb />
 
     @forelse ($invoices as $invoice)
-    <a href="{{ route('invoices.show', $invoice) }}" wire:navigate>
-        <div class="bg-background-secondary hover:bg-background-secondary/80 border border-neutral p-4 rounded-lg mb-4">
-        <div class="flex items-center justify-between mb-2">
-            <div class="flex items-center gap-3">
-            <div class="bg-secondary/10 p-2 rounded-lg">
-                <x-ri-bill-line class="size-5 text-secondary" />
-            </div>
-            <span class="font-medium">{{ !$invoice->number && config('settings.invoice_proforma', false) ? __('invoices.proforma_invoice', ['id' => $invoice->id]) : __('invoices.invoice', ['id' => $invoice->number]) }}</span>
-            <span class="text-base/50 font-semibold">
-                <x-ri-circle-fill class="size-1 text-base/20" />
-            </span>
-            <span class="text-base text-sm">{{ $invoice->formattedTotal }}</span>
-            </div>
-            <div class="size-5 rounded-md p-0.5
-                @if ($invoice->status == 'paid') text-success bg-success/20
-                @elseif($invoice->status == 'cancelled') text-info bg-info/20
-                @else text-warning bg-warning/20
-                @endif">
-                @if ($invoice->status == 'paid')
-                    <x-ri-checkbox-circle-fill />
-                @elseif($invoice->status == 'cancelled')
-                    <x-ri-forbid-fill />
-                @elseif($invoice->status == 'pending')
-                    <x-ri-error-warning-fill />
-                @endif
-            </div>
-        </div>
-        @foreach ($invoice->items as $item)
-            <p class="text-base text-sm">Item(s): {{ $item->description }} ({{ __('invoices.invoice_date')}}: {{ $invoice->created_at->format('d M Y') }})</p>
-        @endforeach
-        </div>
-    </a>
+        <x-invoice-card :invoice="$invoice" />
     @empty
     <div class="bg-background-secondary border border-neutral p-4 rounded-lg">
         <p class="text-base text-sm">{{ __('invoices.no_invoices') }}</p>

--- a/themes/default/views/invoices/show.blade.php
+++ b/themes/default/views/invoices/show.blade.php
@@ -67,6 +67,7 @@
                         <span class="text-yellow-500">{{ __('invoices.payment_pending') }}</span>
                         @endif
                     </div>
+                    @if($this->hasPaymentOptions)
                     <x-button.primary wire:click="$set('showPayModal', true)" class="mt-2" wire:loading.attr="disabled"
                         wire:target="$set('showPayModal')">
                         <span wire:loading wire:target="pay">Processing...</span>
@@ -74,9 +75,14 @@
                     </x-button.primary>
                     @endif
                     @endif
+                    @endif
                 </div>
             </div>
 
+            @php
+                $visibleItems = $invoice->items->filter(fn ($item) => $item->price >= 0);
+                $showQtyColumns = $visibleItems->some(fn ($i) => $i->quantity != 1 || !empty($i->unit));
+            @endphp
             <div class="mt-12 border-b border-neutral overflow-x-auto">
                 <table class="w-full">
                     <thead class="bg-background border border-neutral rounded-lg">
@@ -85,12 +91,14 @@
                                 class="p-4 text-xs font-semibold tracking-wider text-left uppercase rounded-l-lg">
                                 {{ __('invoices.item') }}
                             </th>
+                            @if($showQtyColumns)
                             <th scope="col" class="p-4 text-xs font-semibold tracking-wider text-left uppercase">
                                 {{ __('invoices.price') }}
                             </th>
                             <th scope="col" class="p-4 text-xs font-semibold tracking-wider text-left uppercase">
                                 {{ __('invoices.quantity') }}
                             </th>
+                            @endif
                             <th scope="col"
                                 class="p-4 text-xs font-semibold tracking-wider text-left uppercase rounded-r-lg">
                                 {{ __('invoices.total') }}
@@ -98,30 +106,53 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach ($invoice->items as $item)
+                        @foreach ($visibleItems as $item)
                         <tr>
-                            <td class="p-4 font-normal whitespace-nowrap">
+                            <td class="p-4 font-normal">
                                 @if(in_array($item->reference_type, ['App\Models\Service', 'App\Models\ServiceUpgrade']))
                                 <a href="{{ route('services.show', $item->reference_type == 'App\Models\Service' ? $item->reference_id : $item->reference->service_id) }}"
-                                    class="hover:underline underline-offset-2">{{ $item->description }}
+                                    class="hover:underline underline-offset-2 prose prose-sm dark:prose-invert max-w-none">{!! \Illuminate\Support\Str::markdown($item->description ?? '', ['html_input' => 'strip', 'renderer' => ['soft_break' => "<br />\n"]]) !!}
                                 </a>
                                 @else
-                                {{ $item->description }}
+                                <div class="prose prose-sm dark:prose-invert max-w-none">{!! \Illuminate\Support\Str::markdown($item->description ?? '', ['html_input' => 'strip', 'renderer' => ['soft_break' => "<br />\n"]]) !!}</div>
                                 @endif
                             </td>
-                            <td class="p-4 font-normal whitespace-nowrap text-base">{{ $item->formattedPrice }}
-                            </td>
-                            <td class="p-4 font-normal whitespace-nowrap">{{ $item->quantity }}</td>
+                            @if($showQtyColumns)
+                            <td class="p-4 font-normal whitespace-nowrap text-base">{{ $item->formattedPrice }}</td>
+                            <td class="p-4 font-normal whitespace-nowrap">{{ $item->quantity }}{{ $item->unit ? ' ' . $item->unit : '' }}</td>
+                            @endif
                             <td class="p-4 whitespace-nowrap font-semibold">{{ $item->formattedTotal }}</td>
                         </tr>
                         @endforeach
                     </tbody>
                 </table>
             </div>
+            @php
+                $beforeTaxDiscountItems = $invoice->items->filter(fn ($i) => $i->price < 0 && ! $i->apply_after_tax);
+                $afterTaxDiscountItems = $invoice->items->filter(fn ($i) => $i->price < 0 && $i->apply_after_tax);
+                $positiveItemsTotal = $visibleItems->sum(fn ($i) => $i->price * $i->quantity);
+                $hasBeforeDiscount = $beforeTaxDiscountItems->isNotEmpty();
+                $hasTax = $invoice->formattedTotal->tax > 0;
+            @endphp
             <div class="space-y-3 sm:text-right sm:ml-auto sm:w-72 mt-10">
-                @if ($invoice->formattedTotal->tax > 0)
+                @if ($hasBeforeDiscount)
                 <div class="flex justify-between">
-                    <div class="text-sm font-medium text-gray-500 uppercase dark:text-base">{{ __('invoices.subtotal') }}
+                    <div class="text-sm font-medium text-gray-500 uppercase dark:text-base">{{ __('invoices.subtotal') }}</div>
+                    <div class="text-base font-medium text-gray-900 dark:text-white">
+                        {{ $invoice->formattedTotal->format($positiveItemsTotal) }}
+                    </div>
+                </div>
+                @foreach ($beforeTaxDiscountItems as $discountItem)
+                <div class="flex justify-between">
+                    <div class="text-sm font-medium text-gray-500 uppercase dark:text-base">{{ $discountItem->description }}</div>
+                    <div class="text-base font-medium text-gray-900 dark:text-white">{{ $discountItem->formattedTotal }}</div>
+                </div>
+                @endforeach
+                @endif
+                @if ($hasTax)
+                <div class="flex justify-between">
+                    <div class="text-sm font-medium text-gray-500 uppercase dark:text-base">
+                        {{ $hasBeforeDiscount ? __('invoices.net') : __('invoices.subtotal') }}
                     </div>
                     <div class="text-base font-medium text-gray-900 dark:text-white">
                         {{ $invoice->formattedTotal->format($invoice->formattedTotal->subtotal) }}
@@ -136,10 +167,16 @@
                     </div>
                 </div>
                 @endif
+                @foreach ($afterTaxDiscountItems as $discountItem)
                 <div class="flex justify-between">
-                    <div class="text-base font-semibold text-gray-900 uppercase dark:text-white">Total</div>
+                    <div class="text-sm font-medium text-gray-500 uppercase dark:text-base">{{ $discountItem->description }}</div>
+                    <div class="text-base font-medium text-gray-900 dark:text-white">{{ $discountItem->formattedTotal }}</div>
+                </div>
+                @endforeach
+                <div class="flex justify-between">
+                    <div class="text-base font-semibold text-gray-900 uppercase dark:text-white">{{ __('invoices.total') }}</div>
                     <div class="text-base font-bold text-gray-900 dark:text-white">
-                        {{ $invoice->formattedTotal }}
+                        {{ $invoice->formattedGrandTotal }}
                     </div>
                 </div>
             </div>

--- a/themes/default/views/invoices/widget.blade.php
+++ b/themes/default/views/invoices/widget.blade.php
@@ -1,37 +1,5 @@
 <div class="space-y-4">
     @foreach ($invoices as $invoice)
-    <a href="{{ route('invoices.show', $invoice) }}" wire:navigate>
-        <div class="bg-background-secondary hover:bg-background-secondary/80 border border-neutral p-4 rounded-lg mb-4">
-            <div class="flex items-center justify-between mb-2">
-                <div class="flex items-center gap-3">
-                    <div class="bg-secondary/10 p-2 rounded-lg">
-                        <x-ri-bill-line class="size-5 text-secondary" />
-                    </div>
-                    <span class="font-medium">{{ !$invoice->number && config('settings.invoice_proforma', false) ? __('invoices.proforma_invoice', ['id' => $invoice->id]) : __('invoices.invoice', ['id' => $invoice->number]) }}</span>
-                    <span class="text-base/50 font-semibold">
-                        <x-ri-circle-fill class="size-1 text-base/20" />
-                    </span>
-                    <span class="text-base text-sm">{{ $invoice->formattedTotal }}</span>
-                </div>
-                <div class="size-5 rounded-md p-0.5
-                @if ($invoice->status == 'paid') text-success bg-success/20
-                @elseif($invoice->status == 'cancelled') text-info bg-info/20
-                @else text-warning bg-warning/20
-                @endif">
-                @if ($invoice->status == 'paid')
-                    <x-ri-checkbox-circle-fill />
-                @elseif($invoice->status == 'cancelled')
-                    <x-ri-forbid-fill />
-                @elseif($invoice->status == 'pending')
-                    <x-ri-error-warning-fill />
-                @endif
-            </div>
-            </div>
-            @foreach ($invoice->items as $item)
-            <p class="text-base text-sm text-wrap">Item(s): {{ $item->description }} ({{ __('invoices.invoice_date')}}: {{
-                $invoice->created_at->format('d M Y') }})</p>
-            @endforeach
-        </div>
-    </a>
+        <x-invoice-card :invoice="$invoice" />
     @endforeach
 </div>

--- a/themes/default/views/services/index.blade.php
+++ b/themes/default/views/services/index.blade.php
@@ -1,45 +1,8 @@
 <div class="container mt-14 space-y-4">
     <x-navigation.breadcrumb />
+
     @forelse ($services as $service)
-    <a href="{{ route('services.show', $service) }}" wire:navigate>
-        <div class="bg-background-secondary hover:bg-background-secondary/80 border border-neutral p-4 rounded-lg mb-4">
-        <div class="flex items-center justify-between mb-2">
-            <div class="flex items-center gap-3">
-            <div class="bg-secondary/10 p-2 rounded-lg">
-                <x-ri-instance-line class="size-5 text-secondary" />
-            </div>
-            <span class="font-medium">{{ $service->label }}</span>
-            </div>
-            <div class="size-5 rounded-md p-0.5
-                @if ($service->status == 'active') text-success bg-success/20 
-                @elseif($service->status == 'suspended' || $service->status == 'cancelled') text-inactive bg-inactive/20
-                @else text-warning bg-warning/20 
-                @endif">
-                @if ($service->status == 'active')
-                    <x-ri-checkbox-circle-fill />
-                @elseif($service->status == 'suspended' || $service->status == 'cancelled')
-                    <x-ri-forbid-fill />
-                @elseif($service->status == 'pending')
-                    <x-ri-error-warning-fill />
-                @endif
-            </div>
-        </div>
-        <div class="text-base text-sm flex gap-1">
-            {{
-                in_array($service->plan->type, ['recurring']) ?  __('services.every_period', [
-                'period' => $service->plan->billing_period > 1 ? $service->plan->billing_period : '',
-                'unit' => trans_choice(__('services.billing_cycles.' . $service->plan->billing_unit),
-                $service->plan->billing_period)
-                ]) : '' }}
-                @if($service->expires_at && $service->expires_at > now())
-                -  {{ __('services.renews_in') }} 
-                <x-tooltip :message="$service->expires_at->format('M d, Y')">
-                    {{ $service->expires_at->longAbsoluteDiffForHumans() }}
-                </x-tooltip>
-                @endif
-            </div>
-        </div>
-    </a>
+        <x-service-card :service="$service" />
     @empty
     <div class="bg-background-secondary border border-neutral p-4 rounded-lg">
         <p class="text-base text-sm">{{ __('services.no_services') }}</p>

--- a/themes/default/views/services/widget.blade.php
+++ b/themes/default/views/services/widget.blade.php
@@ -1,33 +1,5 @@
 <div class="space-y-4">
     @foreach ($services as $service)
-    <a href="{{ route('services.show', $service) }}" wire:navigate>
-        <div class="bg-background-secondary hover:bg-background-secondary/80 border border-neutral p-4 rounded-lg mb-4">
-        <div class="flex items-center justify-between mb-2">
-            <div class="flex items-center gap-3">
-            <div class="bg-secondary/10 p-2 rounded-lg">
-                <x-ri-instance-line class="size-5 text-secondary" />
-            </div>
-            <span class="font-medium">{{ $service->product->name }}</span>
-            </div>
-            <div class="size-5 rounded-md p-0.5
-                @if ($service->status == 'active') text-success bg-success/20 
-                @elseif($service->status == 'suspended') text-inactive bg-inactive/20
-                @else text-warning bg-warning/20 
-                @endif">
-                @if ($service->status == 'active')
-                    <x-ri-checkbox-circle-fill />
-                @elseif($service->status == 'suspended')
-                    <x-ri-forbid-fill />
-                @elseif($service->status == 'pending')
-                    <x-ri-error-warning-fill />
-                @endif
-            </div>
-        </div>
-        <p class="text-base text-sm">Product(s): {{ $service->product->category->name }} {{ in_array($service->plan->type, ['recurring']) ? ' - ' . __('services.every_period', [
-            'period' => $service->plan->billing_period > 1 ? $service->plan->billing_period : '',
-            'unit' => trans_choice(__('services.billing_cycles.' . $service->plan->billing_unit), $service->plan->billing_period)
-        ]) : '' }} {{ $service->expires_at ? '- ' . __('services.expires_at') . ': '. $service->expires_at->format('M d, Y') : ''}}</p>
-        </div>
-    </a>
+        <x-service-card :service="$service" />
     @endforeach
 </div>

--- a/themes/default/views/tickets/index.blade.php
+++ b/themes/default/views/tickets/index.blade.php
@@ -6,37 +6,9 @@
             <span>{{ __('ticket.create_ticket') }}</span>
         </x-navigation.link>
     </div>
+
     @forelse ($tickets as $ticket)
-    <a href="{{ route('tickets.show', $ticket) }}" wire:navigate>
-        <div class="bg-background-secondary hover:bg-background-secondary/80 border border-neutral p-4 rounded-lg mb-4">
-            <div class="flex items-center justify-between mb-2">
-                <div class="flex items-center gap-3">
-                    <div class="bg-secondary/10 p-2 rounded-lg">
-                        <x-ri-ticket-line class="size-5 text-secondary" />
-                    </div>
-                    <span class="font-medium">#{{ $ticket->id }} - {{ $ticket->subject }}</span>
-                </div>
-                <div class="size-5 rounded-md p-0.5
-                    @if ($ticket->status == 'open') text-success bg-success/20 
-                    @elseif($ticket->status == 'closed') text-inactive bg-inactive/20
-                    @else text-info bg-info/20 
-                    @endif">
-                    @if ($ticket->status == 'open')
-                        <x-ri-add-circle-fill />
-                    @elseif($ticket->status == 'closed')
-                        <x-ri-forbid-fill />
-                    @elseif($ticket->status == 'replied')
-                        <x-ri-chat-smile-2-fill />
-                    @endif
-                </div>
-            </div>
-            <p class="text-base text-sm">
-                {{ __('ticket.last_activity') }}
-                {{ $ticket->messages()->orderBy('created_at', 'desc')->first()?->created_at->diffForHumans() }}
-                {{ $ticket->department ? ' - ' . $ticket->department : '' }}
-            </p>
-        </div>
-    </a>
+        <x-ticket-card :ticket="$ticket" />
     @empty
     <div class="bg-background-secondary border border-neutral p-4 rounded-lg">
         <p class="text-base text-sm">{{ __('ticket.no_tickets') }}</p>

--- a/themes/default/views/tickets/widget.blade.php
+++ b/themes/default/views/tickets/widget.blade.php
@@ -1,34 +1,5 @@
 <div class="space-y-4">
     @foreach ($tickets as $ticket)
-    <a href="{{ route('tickets.show', $ticket) }}" wire:navigate>
-        <div class="bg-background-secondary hover:bg-background-secondary/80 border border-neutral p-4 rounded-lg mb-4">
-        <div class="flex items-center justify-between mb-2">
-            <div class="flex items-center gap-3">
-            <div class="bg-secondary/10 p-2 rounded-lg">
-                <x-ri-ticket-line class="size-5 text-secondary" />
-            </div>
-            <span class="font-medium">#{{ $ticket->id }} - {{ $ticket->subject }}</span>
-            </div>
-            <div class="size-5 rounded-md p-0.5
-                @if ($ticket->status == 'open') text-success bg-success/20 
-                @elseif($ticket->status == 'closed') text-inactive bg-inactive/20
-                @else text-info bg-info/20 
-                @endif">
-                @if ($ticket->status == 'open')
-                    <x-ri-add-circle-fill />
-                @elseif($ticket->status == 'closed')
-                    <x-ri-forbid-fill />
-                @elseif($ticket->status == 'replied')
-                    <x-ri-chat-smile-2-fill />
-                @endif
-            </div>
-        </div>
-        <p class="text-base text-sm">
-            {{ __('ticket.last_activity') }}
-            {{ $ticket->messages()->orderBy('created_at', 'desc')->first()?->created_at->diffForHumans() }}
-            {{ $ticket->department ? ' - ' . $ticket->department : '' }}
-        </p>
-        </div>
-    </a>
+        <x-ticket-card :ticket="$ticket" />
     @endforeach
 </div>


### PR DESCRIPTION
Adds support for some real world billing edge cases commonly needed for invoicing: after-tax line items, role-restricted coupons, per-item units. Reworks invoice total calculation to correctly handle pre/post-tax discounts and introduces a grand total concept separate from the taxable base.

Also refactors frontend card components to eliminate code duplication and fixes N+1 queries across invoices, services, and tickets. PDF layout improved with proper column and row separation.