### PR TITLE
Fix Mollie wrong URL on cancel

### DIFF
--- a/extensions/Gateways/Mollie/Mollie.php
+++ b/extensions/Gateways/Mollie/Mollie.php
@@ -64,6 +64,7 @@ class Mollie extends Gateway
             ],
             'description' => 'Invoice #' . $invoice->id,
             'redirectUrl' => route('invoices.show', $invoice) . '?checkPayment=true',
+            'cancelUrl' => route('invoices.show', $invoice),
             'webhookUrl' => route('extensions.gateways.mollie.webhook', $invoice),
             'metadata' => [
                 'invoice_id' => $invoice->id,


### PR DESCRIPTION
When a customer cancels at Mollie's hosted checkout, the invoice page gets stuck on a "Payment Processing" spinner with no way to retry. Root cause: the
   pay() method only sets redirectUrl, so Mollie sends the customer back to the same URL regardless of whether they paid or cancelled — and that URL has
  ?checkPayment=true which activates the polling state.

  Mollie's Payments API supports a cancelUrl parameter for exactly this case (docs (https://docs.mollie.com/reference/create-payment)):

  ▎ The URL your customer will be redirected to when the customer explicitly cancels the payment. If this URL is not provided, the customer will be
  ▎ redirected to the redirectUrl instead.

  This PR adds it, pointing at the invoice URL without the polling-state query param.
