### PR TITLE
fix: normalise email case in login rate limit key

### DIFF
--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -27,13 +27,15 @@ class Login extends Component
         $this->captcha();
         $this->validate();
 
-        if (RateLimiter::tooManyAttempts('login:' . $this->email . ':' . request()->ip(), 5)) {
+        $emailKey = strtolower($this->email);
+
+        if (RateLimiter::tooManyAttempts('login:' . $emailKey . ':' . request()->ip(), 5)) {
             $this->addError('email', 'Too many login attempts. Please try again in 60 seconds.');
 
             return;
         }
 
-        RateLimiter::increment('login:' . $this->email . ':' . request()->ip());
+        RateLimiter::increment('login:' . $emailKey . ':' . request()->ip());
 
         // Manually validate credentials instead of Auth::attempt
         $user = User::where('email', $this->email)->first();
@@ -55,7 +57,7 @@ class Login extends Component
             return $this->redirect(route('2fa'), true);
         }
 
-        RateLimiter::clear('login:' . $this->email . ':' . request()->ip());
+        RateLimiter::clear('login:' . $emailKey . ':' . request()->ip());
 
         $loginAction->execute($user, $this->remember);
 


### PR DESCRIPTION
The rate limit key used $this->email directly, which is case-sensitive in Redis but case-insensitive in MariaDB. Varying the case of the email (admin@..., Admin@..., ADMIN@...) produces a fresh rate limit bucket each time while resolving to the same account in the database, allowing unlimited brute force attempts from a single IP.

Normalise the email to lowercase before building the key so both systems agree on identity and the 5-attempt limit is correctly enforced.