### PR TITLE
patch EmailReplyParser

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -55,7 +55,17 @@ class FetchEmails extends Command
                     continue;
                 }
 
-                $body = EmailReplyParser::parseReply($email->text());
+                $rawBody = $email->text() ?? (function($html) {
+                    $dom = new \DOMDocument();
+                    @$dom->loadHTML('<?xml encoding="utf-8" ?>' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+                    foreach (iterator_to_array($dom->getElementsByTagName('blockquote')) as $node) {
+                        $node->parentNode->removeChild($node);
+                    }
+                    $text = strip_tags($dom->saveHTML());
+                    $text = preg_replace('/On .+wrote:\s*/s', '', $text);
+                    return trim($text);
+                })($email->html()) ?? '';
+                $body = EmailReplyParser::parseReply($rawBody);
 
                 // Check headers to see if this email is a reply
                 $replyTo = $email->inReplyTo();
@@ -98,7 +108,7 @@ class FetchEmails extends Command
                     'subject' => $email->subject(),
                     'from' => $email->from()->email(),
                     'to' => $email->to()[0]->email(),
-                    'body' => $email->text(),
+                    'body' => $email->text() ?? $email->html() ?? '',
                     'status' => 'processed',
                 ]);
 
@@ -143,7 +153,7 @@ class FetchEmails extends Command
             'subject' => $email->subject(),
             'from' => $email->from()->email(),
             'to' => $email->to()[0]->email(),
-            'body' => $email->text(),
+            'body' => $email->text() ?? $email->html() ?? '',
             'status' => 'unprocessed',
         ]);
     }

--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -55,23 +55,19 @@ class FetchEmails extends Command
                     continue;
                 }
 
-                $rawBody = $email->text() ?? (function($html) {
-                    $dom = new \DOMDocument();
-                    @$dom->loadHTML('<?xml encoding="utf-8" ?>' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-                    foreach (iterator_to_array($dom->getElementsByTagName('blockquote')) as $node) {
-                        $node->parentNode->removeChild($node);
-                    }
-                    $text = strip_tags($dom->saveHTML());
-                    $text = preg_replace('/On .+wrote:\s*/s', '', $text);
-                    return trim($text);
-                })($email->html()) ?? '';
-                $body = EmailReplyParser::parseReply($rawBody);
+                $rawBody = $email->text();
+                if (empty($rawBody) && $email->html()) {
+                    // If the email has no text body, but has an HTML body, we can strip the HTML tags to get the text
+                    $rawBody = strip_tags($email->html());
+                    $rawBody = html_entity_decode($rawBody, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                }
+                $body = EmailReplyParser::parseReply($rawBody ?? '');
 
                 // Check headers to see if this email is a reply
                 $replyTo = $email->inReplyTo();
                 if (!$replyTo || count($replyTo) === 0) {
                     // Create email log but don't process
-                    $this->failedEmailLog($email);
+                    $this->failedEmailLog($email, $body);
 
                     continue;
                 }
@@ -79,7 +75,7 @@ class FetchEmails extends Command
                 // Validate if in reply to another ticket (<ticket message id>@hostname)
 
                 if (!preg_match('/^(\d+)@/', $replyTo[0], $matches)) {
-                    $this->failedEmailLog($email);
+                    $this->failedEmailLog($email, $body);
 
                     continue;
                 }
@@ -88,7 +84,7 @@ class FetchEmails extends Command
                 // Check if the ticket exists
                 $ticketMessage = TicketMessage::find($ticketMessageId);
                 if (!$ticketMessage) {
-                    $this->failedEmailLog($email);
+                    $this->failedEmailLog($email, $body);
 
                     continue;
                 }
@@ -97,7 +93,7 @@ class FetchEmails extends Command
 
                 // Check if from email matches ticket's email
                 if ($email->from()->email() !== $ticket->user->email) {
-                    $this->failedEmailLog($email);
+                    $this->failedEmailLog($email, $body);
 
                     continue;
                 }
@@ -108,7 +104,7 @@ class FetchEmails extends Command
                     'subject' => $email->subject(),
                     'from' => $email->from()->email(),
                     'to' => $email->to()[0]->email(),
-                    'body' => $email->text() ?? $email->html() ?? '',
+                    'body' => $body,
                     'status' => 'processed',
                 ]);
 
@@ -146,14 +142,14 @@ class FetchEmails extends Command
         }
     }
 
-    private function failedEmailLog($email): TicketMailLog
+    private function failedEmailLog($email, $body): TicketMailLog
     {
         return TicketMailLog::create([
             'message_id' => $email->messageId(),
             'subject' => $email->subject(),
             'from' => $email->from()->email(),
             'to' => $email->to()[0]->email(),
-            'body' => $email->text() ?? $email->html() ?? '',
+            'body' => $body,
             'status' => 'unprocessed',
         ]);
     }


### PR DESCRIPTION
Resolves #1236 

- Fall back to `$email->html()` when `$email->text()` is null, in both the success path and `failedEmailLog()`, preventing null constraint violations on `ticket_mail_logs.body`
- Strip `<blockquote>` elements from HTML before text extraction to remove quoted previous messages from the stored reply
- Strip the `On <date>, X wrote:` attribution line left behind after blockquote removal
- Use `<?xml encoding="utf-8" ?>` prefix when loading HTML into `DOMDocument` to prevent UTF-8 characters (e.g. Swedish Å Ä Ö) from being mangled
- Plain-text emails are unaffected — the HTML parsing path is only taken when `$email->text()` is null