### PR TITLE
Honor snapshot tax in Price to prevent breakdown drift on paid invoices

### DIFF
--- a/app/Classes/Price.php
+++ b/app/Classes/Price.php
@@ -78,7 +78,7 @@ class Price
 
         // Calculate taxes
         if (config('settings.tax_enabled', false)) {
-            $tax ??= Settings::tax();
+            $tax ??= $priceAndCurrency->tax ?? Settings::tax();
             if ($tax) {
                 // Inclusive has the tax included in the price
                 if (config('settings.tax_type', 'inclusive') == 'inclusive' || !$apply_exclusive_tax) {


### PR DESCRIPTION
Invoice::formattedTotal() passes 'tax' => $this->tax to new Price(...)
but the Price constructor never reads the tax key from the array —it falls straight through to Settings::tax() live. 
Result:  when a tax rate is edited after an invoice is paid.

The snapshot's tax_rate label stays correct but the displayed subtotal/tax amounts silently drift to the new rate.

One-line fix in app/Classes/Price.php:81 — honor the array-passed tax before falling back to live:

$tax ??= $priceAndCurrency->tax ?? Settings::tax();