### PR TITLE
feat: Include renewal invoice details in service suspension notifications

### DIFF
--- a/app/Jobs/Server/SuspendJob.php
+++ b/app/Jobs/Server/SuspendJob.php
@@ -41,6 +41,19 @@ class SuspendJob implements ShouldQueue
         }
 
         if ($this->sendNotification) {
+            // Find the pending renewal invoice for this service so we can
+            // include the amount due and a direct payment link in the notification
+            $pendingInvoice = $this->service->invoices()
+                ->where('status', 'pending')
+                ->latest()
+                ->first();
+
+            if ($pendingInvoice) {
+                $data['invoice'] = $pendingInvoice;
+                $data['invoiceTotal'] = $pendingInvoice->formattedTotal;
+                $data['invoiceItems'] = $pendingInvoice->items;
+            }
+
             NotificationHelper::serverSuspendedNotification($this->service->user, $this->service, is_array($data) ? $data : []);
         }
     }

--- a/database/migrations/2026_05_29_000000_update_server_suspended_notification_template.php
+++ b/database/migrations/2026_05_29_000000_update_server_suspended_notification_template.php
@@ -1,0 +1,89 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * The original template body that shipped with Paymenter.
+     * We only update templates that still match this exact default,
+     * so admin-customized templates are never overwritten.
+     */
+    private const ORIGINAL_BODY = <<<'HTML'
+                # Service suspended
+
+                Your service has been suspended due to a payment failure.
+
+                **Service details**
+                - Name: {{ $service->product->name }}
+
+                Please pay the invoice to reactivate the service.
+                HTML;
+
+    private const ORIGINAL_IN_APP_BODY = 'Your service {{ $service->product->name }} has been suspended due to a payment failure. Please pay the invoice to reactivate the service.';
+
+    private const NEW_BODY = <<<'HTML'
+                # Service suspended
+
+                Your service has been suspended due to a payment failure.
+
+                **Service details**
+                - Name: {{ $service->product->name }}
+
+                @isset($invoice)
+                **Invoice details**
+                - Invoice #: {{ $invoice->id }}
+                - Amount due: **{{ $invoiceTotal }}**
+
+                <div class="table">
+
+                |   Item   | Quantity |  Price   |
+                | :------: | :------: | :------: |
+                @foreach ($invoiceItems as $item)
+                | {{ $item->description }} | {{ $item->quantity }} | {{ $item->price }} |
+                @endforeach
+                </div>
+
+                <div class="action">
+                	<a class="button button-blue" href="{{ route('invoices.show', $invoice) }}">
+                		Pay Invoice & Reactivate
+                	</a>
+                </div>
+                @else
+                Please pay the outstanding invoice to reactivate your service.
+
+                <div class="action">
+                	<a class="button button-blue" href="{{ route('invoices') }}">
+                		View Invoices
+                	</a>
+                </div>
+                @endisset
+                HTML;
+
+    private const NEW_IN_APP_BODY = 'Your service {{ $service->product->name }} has been suspended. @isset($invoice) Pay {{ $invoiceTotal }} to reactivate. @endisset';
+
+    public function up(): void
+    {
+        // Only update if the template body still matches the original default.
+        // This ensures admin-customized templates are never overwritten.
+        DB::table('notification_templates')
+            ->where('key', 'server_suspended')
+            ->where('body', self::ORIGINAL_BODY)
+            ->update([
+                'body' => self::NEW_BODY,
+                'in_app_body' => self::NEW_IN_APP_BODY,
+            ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('notification_templates')
+            ->where('key', 'server_suspended')
+            ->where('body', self::NEW_BODY)
+            ->update([
+                'body' => self::ORIGINAL_BODY,
+                'in_app_body' => self::ORIGINAL_IN_APP_BODY,
+            ]);
+    }
+};

--- a/database/seeders/EmailTemplateSeeder.php
+++ b/database/seeders/EmailTemplateSeeder.php
@@ -172,10 +172,37 @@ class EmailTemplateSeeder extends Seeder
                 **Service details**
                 - Name: {{ $service->product->name }}
 
-                Please pay the invoice to reactivate the service.
+                @isset($invoice)
+                **Invoice details**
+                - Invoice #: {{ $invoice->id }}
+                - Amount due: **{{ $invoiceTotal }}**
+
+                <div class="table">
+
+                |   Item   | Quantity |  Price   |
+                | :------: | :------: | :------: |
+                @foreach ($invoiceItems as $item)
+                | {{ $item->description }} | {{ $item->quantity }} | {{ $item->price }} |
+                @endforeach
+                </div>
+
+                <div class="action">
+                	<a class="button button-blue" href="{{ route('invoices.show', $invoice) }}">
+                		Pay Invoice & Reactivate
+                	</a>
+                </div>
+                @else
+                Please pay the outstanding invoice to reactivate your service.
+
+                <div class="action">
+                	<a class="button button-blue" href="{{ route('invoices') }}">
+                		View Invoices
+                	</a>
+                </div>
+                @endisset
                 HTML,
             'in_app_title' => 'Service suspended',
-            'in_app_body' => 'Your service {{ $service->product->name }} has been suspended due to a payment failure. Please pay the invoice to reactivate the service.',
+            'in_app_body' => 'Your service {{ $service->product->name }} has been suspended. @isset($invoice) Pay {{ $invoiceTotal }} to reactivate. @endisset',
             'mail_enabled' => 'force',
             'in_app_enabled' => 'choice_on',
             'edit_preference_message' => 'Alert me about service suspensions',


### PR DESCRIPTION
## Summary

When a service is suspended due to non-payment, the suspension notification now includes the pending renewal invoice details — amount due, itemized breakdown, and a direct "Pay Invoice & Reactivate" button.

### Problem

Currently, the suspension email only says:
> "Your service has been suspended due to a payment failure. Please pay the invoice to reactivate the service."

It doesn't tell the user **which invoice**, **how much they owe**, or provide a **direct payment link**. Users have to log in, navigate to invoices, and find the right one manually.

### Solution

The `SuspendJob` now looks up the pending renewal invoice (which the CronJob has already created before suspension) and passes it to the notification template.

**Before:**
- Service name only
- No invoice info
- No payment link

**After:**
- Service name
- Invoice number and amount due
- Itemized table (same format as invoice created email)
- Direct "Pay Invoice & Reactivate" button
- Falls back gracefully when no invoice exists

### Changes

| File | Change |
|------|--------|
| `app/Jobs/Server/SuspendJob.php` | Look up pending invoice, pass to notification |
| `database/seeders/EmailTemplateSeeder.php` | Updated template with conditional invoice block |
| `database/migrations/2026_05_29_...` | Conditionally updates existing templates (only if unmodified) |

### Backward Compatibility

- ✅ **No breaking changes** — the extra data keys are simply additional Blade template variables
- ✅ **Admin-customized templates preserved** — the migration only updates templates that still match the original default body
- ✅ **Graceful fallback** — if no pending invoice exists, falls back to generic "View Invoices" link
- ✅ **No new dependencies** — uses existing models and relationships

### Testing

1. Create a service with an active recurring billing cycle
2. Let the invoice generate via cron (or create manually)
3. Trigger suspension (let service expire past the suspend threshold)
4. Check the suspension email — it now includes invoice details and payment link