### PR TITLE
Update Deprecated CheckForAnyScope to CheckTokenForAnyScope for Laravel 13.7.x

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,7 @@ use App\Models\DebugLog;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
-use Laravel\Passport\Http\Middleware\CheckForAnyScope;
+use Laravel\Passport\Http\Middleware\CheckTokenForAnyScope;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -25,7 +25,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->append(ProxyMiddleware::class);
         $middleware->alias([
             'has' => EnsureUserHasPermissions::class,
-            'scope' => CheckForAnyScope::class,
+            'scope' => CheckTokenForAnyScope::class,
             'api.admin' => AdminApi::class,
             'checkout' => CheckoutParameterMiddleware::class,
         ]);


### PR DESCRIPTION
1. Paymenter's https://github.com/Paymenter/Paymenter/blob/master/bootstrap/app.php currently imports Laravel\Passport\Http\Middleware\CheckForAnyScope.
2. Paymenter's current passport.lock pins laravel/passport to v13.7.5. https://github.com/Paymenter/Paymenter/blob/9d2f961efeeee59dd35d54237b64cfe3a9686c23/composer.lock#L3032-L3039
3. Passport v13.7.x renamed `CheckForAnyScope` -> `CheckTokenForAnyScope` upstream in Passport. https://github.com/laravel/passport/blob/13.x/UPGRADE.md#renamed-middlewares

As a result a new Paymenter install boots but throws `Class does not exist` the moment any scope-middleware'd route is hit (bug experienced in OAuth callback).