### PR TITLE
Add `:heavy` image and fix update flow

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -56,9 +56,9 @@ if [ -z "$PAYMENTER_SKIP_DEFAULT" ] || [ "$PAYMENTER_SKIP_DEFAULT" != "true" ]; 
   echo -e "Renewing default themes and extensions..."
   
   # Renew default themes
-  if [ -d /app/themes_default ] && [ -d /app/themes ]; then
+  if [ -d /app/default/themes ] && [ -d /app/themes ]; then
     echo -e "Renewing themes from defaults..."
-    for item in /app/themes_default/*; do
+    for item in /app/default/themes/*; do
       if [ -e "$item" ]; then
         item_name=$(basename "$item")
         rm -rf "/app/themes/$item_name"
@@ -69,10 +69,10 @@ if [ -z "$PAYMENTER_SKIP_DEFAULT" ] || [ "$PAYMENTER_SKIP_DEFAULT" != "true" ]; 
   fi
   
   # Renew default extensions - only those that already exist
-  if [ -d /app/extensions_default ] && [ -d /app/extensions ]; then
+  if [ -d /app/default/extensions ] && [ -d /app/extensions ]; then
     echo -e "Renewing extensions from defaults..."
     updated_any=0
-    for item in /app/extensions_default/*; do
+    for item in /app/default/extensions/*; do
       if [ -e "$item" ]; then
         item_name=$(basename "$item")
         # Only update if extension category exists in /app/extensions
@@ -83,7 +83,7 @@ if [ -z "$PAYMENTER_SKIP_DEFAULT" ] || [ "$PAYMENTER_SKIP_DEFAULT" != "true" ]; 
             for ext_dir in "/app/extensions/$item_name"/*; do
               if [ -d "$ext_dir" ]; then
                 ext_name=$(basename "$ext_dir")
-                default_ext="/app/extensions_default/$item_name/$ext_name"
+                default_ext="/app/default/extensions/$item_name/$ext_name"
                 if [ -d "$default_ext" ]; then
                   rm -rf "$ext_dir"
                   cp -rp "$default_ext" "$ext_dir"
@@ -112,8 +112,8 @@ fi
 if [ ! -d /app/themes ] || [ -z "$(ls -A /app/themes 2>/dev/null)" ]; then
   echo -e "Themes directory is empty, copying default themes..."
   mkdir -p /app/themes
-  if [ -d /app/themes_default ]; then
-    cp -rp /app/themes_default/. /app/themes/
+  if [ -d /app/default/themes ]; then
+    cp -rp /app/default/themes/. /app/themes/
     chown -R nginx:nginx /app/themes
     chmod -R 755 /app/themes
     echo -e "Default themes copied."
@@ -126,14 +126,35 @@ fi
 if [ ! -d /app/extensions ] || [ -z "$(ls -A /app/extensions 2>/dev/null)" ]; then
   echo -e "Extensions directory is empty, copying default extensions..."
   mkdir -p /app/extensions
-  if [ -d /app/extensions_default ]; then
-    cp -rp /app/extensions_default/. /app/extensions/
+  if [ -d /app/default/extensions ]; then
+    cp -rp /app/default/extensions/. /app/extensions/
     chown -R nginx:nginx /app/extensions
     chmod -R 755 /app/extensions
     echo -e "Default extensions copied."
   fi
 else
   echo -e "Extensions directory already populated."
+fi
+
+## seed / renew the default theme's compiled bundle when a /app/default/build
+## snapshot exists (heavy image). Safe no-op on the standard image. The bundled
+## `default` theme writes to /app/public/default/ via laravel-vite-plugin's
+## buildDirectory.
+if [ -d /app/default/build ]; then
+  if [ ! -d /app/public/default ] || [ -z "$(ls -A /app/public/default 2>/dev/null)" ]; then
+    echo -e "public/default is empty, seeding from defaults..."
+    mkdir -p /app/public/default
+    cp -rp /app/default/build/. /app/public/default/
+    chown -R nginx:nginx /app/public/default
+    echo -e "Default public/default seeded."
+  elif [ -z "$PAYMENTER_SKIP_DEFAULT" ] || [ "$PAYMENTER_SKIP_DEFAULT" != "true" ]; then
+    echo -e "Renewing public/default from defaults..."
+    rm -rf /app/public/default/*
+    cp -rp /app/default/build/. /app/public/default/
+    chown -R nginx:nginx /app/public/default
+  else
+    echo -e "PAYMENTER_SKIP_DEFAULT is set, leaving public/default untouched."
+  fi
 fi
 
 ## set permissions for themes and extensions

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,3 +59,34 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # ---------------------------------------------------------------- #
+      # Heavy image                                                      #
+      # ---------------------------------------------------------------- #
+      # Self-contained variant (PHP vendor, built assets, default themes
+      # and default extensions all baked in). Designed to be used with
+      # docker-compose.heavy.yml — no asset-builder sidecar and no `app:`
+      # named volume, so `docker compose pull` is enough to update.
+      - name: Fetch heavy metadata
+        id: metadata_heavy
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/paymenter/paymenter
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=heavy,enable=${{ github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease == false }}
+            type=ref,event=tag,prefix=heavy-
+            type=ref,event=branch,prefix=heavy-
+
+      - name: Build and Push (heavy)
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile.heavy
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          labels: ${{ steps.metadata_heavy.outputs.labels }}
+          tags: ${{ steps.metadata_heavy.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,12 @@ RUN npm run build
 FROM final AS production
 COPY --from=build /app/public /app/public
 
-# Copy themes and extensions to default locations for renewal on startup
-RUN cp -r /app/themes /app/themes_default && \
-    cp -r /app/extensions /app/extensions_default
+# Copy themes, extensions and (in heavy) the built bundle to a single
+# /app/default/ tree so the entrypoint can renew bind-mounted copies
+# on startup.
+RUN mkdir -p /app/default && \
+    cp -r /app/themes      /app/default/themes && \
+    cp -r /app/extensions  /app/default/extensions
 
 # Environment variable to skip default themes/extensions renewal
 # Set PAYMENTER_SKIP_DEFAULT=true to keep any custom modifications to defaults

--- a/Dockerfile.heavy
+++ b/Dockerfile.heavy
@@ -1,0 +1,109 @@
+# syntax=docker/dockerfile:1.6
+#
+# Paymenter "heavy" image
+# ------------------------------------------------------------------
+# Same runtime as the standard image (PHP-FPM + nginx + supervisord,
+# vendor, pre-built public/ assets, default themes & extensions) PLUS
+# all the build tooling needed to rebuild frontend assets from inside
+# the running container:
+#
+#   * node 22 + npm
+#   * composer
+#   * the C toolchain (autoconf, make, g++, gcc, libc-dev) and the
+#     -dev headers required by the PHP extensions are kept installed
+#     so that `composer install` (with dev deps) and native rebuilds
+#     keep working.
+#
+# Typical workflow once the stack is running:
+#
+#   docker compose exec paymenter sh -c "npm install && npm run build"
+#
+# This replaces the previous `asset-builder` sidecar service.
+#
+
+# ---------------------------------------------------------------- #
+# Stage 1: PHP runtime + composer dependencies                     #
+# Build deps are intentionally kept installed in this stage.       #
+# ---------------------------------------------------------------- #
+FROM --platform=$TARGETOS/$TARGETARCH php:8.3-fpm-alpine AS final
+WORKDIR /app
+
+RUN apk add --no-cache --update \
+        ca-certificates dcron curl git supervisor tar unzip nginx \
+        libpng-dev libxml2-dev libzip-dev icu-dev gmp-dev \
+        autoconf make g++ gcc libc-dev linux-headers \
+        nodejs npm bash \
+    && docker-php-ext-configure zip \
+    && docker-php-ext-install bcmath gd pdo_mysql zip intl sockets gmp \
+    && pecl install redis \
+    && docker-php-ext-enable redis
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --no-autoloader --no-scripts
+
+COPY . ./
+RUN composer install --no-dev --optimize-autoloader
+
+RUN cp .env.example .env \
+    && chmod 777 -R bootstrap storage/* \
+    && rm -rf .env bootstrap/cache/*.php \
+    && chown -R nginx:nginx . \
+    && rm /usr/local/etc/php-fpm.conf \
+    && echo "* * * * * /usr/local/bin/php /app/artisan schedule:run >> /dev/null 2>&1" >> /var/spool/cron/crontabs/root \
+    && mkdir -p /var/run/php /var/run/nginx
+
+# ---------------------------------------------------------------- #
+# Stage 2: Build the frontend assets                               #
+# ---------------------------------------------------------------- #
+FROM --platform=$TARGETOS/$TARGETARCH node:22-alpine AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm install
+
+COPY . ./
+COPY --from=final /app/vendor /app/vendor
+RUN npm run build
+
+# ---------------------------------------------------------------- #
+# Stage 3: Heavy production image                                  #
+# ---------------------------------------------------------------- #
+FROM final AS production
+
+# Bring in compiled public assets from the build stage
+COPY --from=build /app/public        /app/public
+# Bring in the resolved node_modules so `npm run build` works
+# out of the box on first `docker compose exec`.
+COPY --from=build /app/node_modules  /app/node_modules
+
+# Snapshot default themes and extensions so the entrypoint can
+# renew the bind-mounted copies on every container start.
+RUN cp -r /app/themes      /app/themes_default \
+ && cp -r /app/extensions  /app/extensions_default
+
+# Pre-create the persistent .env directory expected by entrypoint.sh
+# (mounted as ./var:/app/var in docker-compose.heavy.yml).
+RUN mkdir -p /app/var \
+ && chown -R nginx:nginx /app/var /app/node_modules
+
+# Set PAYMENTER_SKIP_DEFAULT=true to preserve manual edits to
+# bind-mounted themes/extensions across image upgrades.
+ENV PAYMENTER_SKIP_DEFAULT=false
+
+COPY .github/docker/default.conf  /etc/nginx/http.d/default.conf
+COPY .github/docker/www.conf      /usr/local/etc/php-fpm.conf
+COPY .github/docker/supervisord.conf /etc/supervisord.conf
+
+# Paths that callers are expected to persist via bind mounts.
+# /app itself is intentionally NOT a volume — application code lives
+# in the image layers and updates atomically with `docker compose pull`.
+VOLUME ["/app/var", "/app/storage/logs", "/app/storage/app/public", "/app/themes", "/app/extensions"]
+
+LABEL org.opencontainers.image.title="Paymenter (heavy)" \
+      org.opencontainers.image.description="Self-contained Paymenter image with prebuilt assets, default themes/extensions and the full build toolchain (node, npm, composer, native build deps) so frontend assets can be rebuilt inside the running container." \
+      org.opencontainers.image.source="https://github.com/paymenter/paymenter"
+
+EXPOSE 80
+ENTRYPOINT [ "/bin/ash", ".github/docker/entrypoint.sh" ]
+CMD [ "supervisord", "-n", "-c", "/etc/supervisord.conf" ]

--- a/Dockerfile.heavy
+++ b/Dockerfile.heavy
@@ -77,10 +77,15 @@ COPY --from=build /app/public        /app/public
 # out of the box on first `docker compose exec`.
 COPY --from=build /app/node_modules  /app/node_modules
 
-# Snapshot default themes and extensions so the entrypoint can
-# renew the bind-mounted copies on every container start.
-RUN cp -r /app/themes      /app/themes_default \
- && cp -r /app/extensions  /app/extensions_default
+# Snapshot default themes, extensions and the default theme's compiled
+# public bundle into a single /app/default/ tree so the entrypoint can
+# seed/renew bind-mounted copies on every start. (laravel-vite-plugin
+# writes to public/<buildDirectory>/; the bundled `default` theme uses
+# buildDirectory: 'default/'.)
+RUN mkdir -p /app/default && \
+    cp -r /app/themes         /app/default/themes && \
+    cp -r /app/extensions     /app/default/extensions && \
+    cp -r /app/public/default /app/default/build
 
 # Pre-create the persistent .env directory expected by entrypoint.sh
 # (mounted as ./var:/app/var in docker-compose.heavy.yml).

--- a/docker-compose.beta.yml
+++ b/docker-compose.beta.yml
@@ -35,13 +35,15 @@ services:
     restart: always
     ports:
       - "80:80"
+    # Only persistent paths are bind-mounted. /app itself is NOT mounted,
+    # so `docker compose pull && docker compose up -d` is enough to update
+    # — no volume removal required.
     volumes:
-      - "./:/app/var/"
-      - "./storage/logs:/app/storage/logs"
-      - "./storage/public:/app/storage/app/public"
-      - "./themes:/app/themes"
-      - "./extensions:/app/extensions"
-      - "app:/app"
+      - "./var:/app/var"                              # .env (auto-generated on first run)
+      - "./storage/logs:/app/storage/logs"            # Laravel logs
+      - "./storage/public:/app/storage/app/public"    # user uploads
+      - "./themes:/app/themes"                        # user-customizable themes
+      - "./extensions:/app/extensions"                # user-customizable extensions
     environment:
       DB_PASSWORD: *db-password
       APP_ENV: "production"
@@ -53,28 +55,11 @@ services:
       # Set to "true" to skip renewal of default themes and extensions
       # By default, default themes and extensions are always renewed on startup
       PAYMENTER_SKIP_DEFAULT: "false"
-    networks:
-      - paymenter_nw
-  # Asset Builder Service - used to build frontend assets (themes/extensions)
-  asset-builder:
-    image: node:22-alpine
-    profiles: ["build"]
-    working_dir: /app
-    volumes:
-      - "./themes:/app/themes"
-      - "./extensions:/app/extensions"
-      - "./:/app/var"
-      - "app:/app"
-    command: >
-      sh -c "echo 'Asset Builder ready for npm commands' &&
-      echo 'Working directory: /app' &&
-      echo 'Usage: docker compose run --rm asset-builder npm install && npm run build' &&
-      tail -f /dev/null"
+    depends_on:
+      - database
+      - cache
     networks:
       - paymenter_nw
 networks:
   paymenter_nw:
     driver: bridge
-
-volumes:
-  app:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -35,13 +35,15 @@ services:
     restart: always
     ports:
       - "80:80"
+    # Only persistent paths are bind-mounted. /app itself is NOT mounted,
+    # so `docker compose pull && docker compose up -d` is enough to update
+    # — no volume removal required.
     volumes:
-      - "./:/app/var/"
-      - "./storage/logs:/app/storage/logs"
-      - "./storage/public:/app/storage/app/public"
-      - "./themes:/app/themes"
-      - "./extensions:/app/extensions"
-      - "app:/app"
+      - "./var:/app/var" # .env (auto-generated on first run)
+      - "./storage/logs:/app/storage/logs" # Laravel logs
+      - "./storage/public:/app/storage/app/public" # user uploads
+      - "./themes:/app/themes" # user-customizable themes
+      - "./extensions:/app/extensions" # user-customizable extensions
     environment:
       DB_PASSWORD: *db-password
       APP_ENV: "production"
@@ -53,28 +55,11 @@ services:
       # Set to "true" to skip renewal of default themes and extensions
       # By default, default themes and extensions are always renewed on startup
       PAYMENTER_SKIP_DEFAULT: "false"
-    networks:
-      - paymenter_nw
-  # Asset Builder Service - used to build frontend assets (themes/extensions)
-  asset-builder:
-    image: node:22-alpine
-    profiles: ["build"]
-    working_dir: /app
-    volumes:
-      - "./themes:/app/themes"
-      - "./extensions:/app/extensions"
-      - "./:/app/var"
-      - "app:/app"
-    command: >
-      sh -c "echo 'Asset Builder ready for npm commands' &&
-      echo 'Working directory: /app' &&
-      echo 'Usage: docker compose run --rm asset-builder npm install && npm run build' &&
-      tail -f /dev/null"
+    depends_on:
+      - database
+      - cache
     networks:
       - paymenter_nw
 networks:
   paymenter_nw:
     driver: bridge
-
-volumes:
-  app:

--- a/docker-compose.heavy.yml
+++ b/docker-compose.heavy.yml
@@ -1,0 +1,94 @@
+#
+# Paymenter — "heavy" image compose file
+# ---------------------------------------------------------------------------
+# This compose file uses the self-contained `:heavy` image (built from
+# Dockerfile.heavy). The image ships with PHP vendor, pre-built frontend
+# assets, default themes and default extensions AND the full build
+# toolchain (node, npm, composer, native build deps), so frontend assets
+# can be rebuilt directly inside the running container — no sidecar.
+#
+# Updating to a new release:
+#
+#     docker compose -f docker-compose.heavy.yml pull
+#     docker compose -f docker-compose.heavy.yml up -d
+#
+# You do NOT need to remove any volume to pick up new application code,
+# because nothing is mounted over /app. Only paths that must persist
+# (env file, logs, user uploads, themes, extensions) are bind-mounted.
+#
+# Rebuilding theme / extension assets in-place (e.g. after editing a
+# theme on the host):
+#
+#     docker compose -f docker-compose.heavy.yml exec paymenter \
+#         sh -c "npm install && npm run build"
+# ---------------------------------------------------------------------------
+
+x-common:
+  database: &db-environment
+    # Do not remove the "&db-password" anchor below — it is referenced
+    # from the paymenter service.
+    MYSQL_PASSWORD: &db-password "CHANGE_ME"
+    MYSQL_ROOT_PASSWORD: "CHANGE_ME_TOO"
+
+#
+# ------------------------------------------------------------------------------------------
+# DANGER ZONE BELOW
+#
+# The remainder of this file likely does not need to be changed. Please only make
+# modifications below if you understand what you are doing.
+#
+services:
+  database:
+    image: mariadb:lts
+    restart: always
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - "./database:/var/lib/mysql"
+    environment:
+      <<: *db-environment
+      MYSQL_DATABASE: "paymenter"
+      MYSQL_USER: "paymenter"
+    networks:
+      - paymenter_nw
+
+  cache:
+    image: redis:alpine
+    restart: always
+    networks:
+      - paymenter_nw
+
+  paymenter:
+    image: ghcr.io/paymenter/paymenter:heavy
+    restart: always
+    ports:
+      - "80:80"
+    # Only persistent paths are bind-mounted. /app itself is NOT mounted,
+    # so `docker compose pull` is sufficient to update the application.
+    volumes:
+      - "./var:/app/var" # .env (auto-generated on first run)
+      - "./storage/logs:/app/storage/logs" # Laravel logs
+      - "./storage/public:/app/storage/app/public" # user uploads
+      - "./themes:/app/themes" # user-customizable themes
+      - "./extensions:/app/extensions" # user-customizable extensions
+    environment:
+      DB_PASSWORD: *db-password
+      APP_ENV: "production"
+      CACHE_STORE: "redis"
+      REDIS_HOST: "cache"
+      DB_CONNECTION: "mariadb"
+      DB_HOST: "database"
+      DB_PORT: "3306"
+      # Set to "true" to keep your manual edits to bind-mounted themes
+      # and extensions across image upgrades. When "false" (default),
+      # the entrypoint refreshes them from the image's baked-in
+      # /app/themes_default and /app/extensions_default on every start.
+      PAYMENTER_SKIP_DEFAULT: "false"
+    depends_on:
+      - database
+      - cache
+    networks:
+      - paymenter_nw
+
+networks:
+  paymenter_nw:
+    driver: bridge

--- a/docker-compose.heavy.yml
+++ b/docker-compose.heavy.yml
@@ -70,6 +70,27 @@ services:
       - "./storage/public:/app/storage/app/public" # user uploads
       - "./themes:/app/themes" # user-customizable themes
       - "./extensions:/app/extensions" # user-customizable extensions
+      # ---------------------------------------------------------------
+      # OPTIONAL: persist the default theme's compiled bundle across
+      # container recreates. The bundled `default` theme writes its
+      # Vite output to /app/public/default/ (see
+      # themes/default/vite.config.js -> buildDirectory: 'default/').
+      #
+      # Convention: ./build/<themename> on the host  <->  /app/public/<themename>
+      # in the container. One subdirectory per theme, all under ./build/.
+      #
+      # Safe to enable on a fresh setup: when the host directory is
+      # empty the entrypoint seeds it from the image's baked-in snapshot
+      # at /app/default/build, so the theme keeps working.
+      #
+      # On image updates the entrypoint refreshes this directory from
+      # the new image (unless PAYMENTER_SKIP_DEFAULT is set).
+      #
+      # For CUSTOM themes that set their own buildDirectory (e.g.
+      # 'mytheme/'), add a parallel mount following the same pattern:
+      #   - "./build/mytheme:/app/public/mytheme"
+      # ---------------------------------------------------------------
+      # - "./build/default:/app/public/default"
     environment:
       DB_PASSWORD: *db-password
       APP_ENV: "production"


### PR DESCRIPTION
## What does this PR do?

- **New `:heavy` Docker image** ([Dockerfile.heavy](Dockerfile.heavy))
  Same as the standard image, but with the full build toolchain baked in
  (node, npm, composer, native build deps, pre-installed `node_modules`).
  Lets you rebuild theme/extension assets directly inside the running
  container — no `asset-builder` sidecar needed:

  ```bash
  docker compose exec paymenter sh -c "npm install && npm run build"
  ```

- **New compose file** [docker-compose.heavy.yml](docker-compose.heavy.yml)
  using `ghcr.io/paymenter/paymenter:heavy`.

- **Updates no longer require removing the `app:` volume.**
  [docker-compose.example.yml](docker-compose.example.yml) and
  [docker-compose.beta.yml](docker-compose.beta.yml) no longer mount a
  named volume over `/app`. Only the paths that actually need to persist
  are bind-mounted (`./var`, `storage/logs`, `storage/app/public`,
  `themes`, `extensions`). The `asset-builder` sidecar (which only
  existed because of that volume) has been removed.

  Updating is now simply:

  ```bash
  docker compose pull
  docker compose up -d
  ```

- **Snapshot layout consolidated** under `/app/default/`:

  | Old | New |
  | --- | --- |
  | `/app/themes_default` | `/app/default/themes` |
  | `/app/extensions_default` | `/app/default/extensions` |
  | `/app/public/default_default` | `/app/default/build` *(heavy only)* |

  Image and entrypoint always ship together, so this is internal but
  flagged here for anyone who scripted against the old `*_default`
  paths.

## Why the changes

The `app:` named volume overlaid the entire `/app` directory of the
image, hiding new code on every pull. Users had to wipe the volume to
update, which also wiped any in-volume state. Mounting only the paths
that need persistence fixes this for both the standard and heavy
images.

## Files changed

- `Dockerfile.heavy` (new)
- `docker-compose.heavy.yml` (new)
- `Dockerfile` — snapshot dirs consolidated under `/app/default/`
- `docker-compose.example.yml` — drop `app:` volume + `asset-builder`
- `docker-compose.beta.yml` — drop `app:` volume + `asset-builder`
- `.github/docker/entrypoint.sh` — read snapshots from
  `/app/default/{themes,extensions,build}`; seed/renew
  `/app/public/default` from `/app/default/build` when present
- `.github/workflows/docker.yaml` — also build & push `:heavy`,
  `:heavy-master`, `:heavy-<tag>`

## Not yet verified

- The new GitHub Actions step that builds and pushes the `:heavy` image
  hasn't been run yet. Needs a CI run on this branch to confirm the
  multi-arch build succeeds and the tags land in GHCR.

## Persisting the default theme's build (optional)

The bundled `default` theme compiles to `/app/public/default/` (per
`themes/default/vite.config.js` → `buildDirectory: 'default/'`). By
default this directory is **not** bind-mounted, so:

- Default-theme assets always come from the image — updates "just work".
- If you rebuild it inside the container with `npm run build`, the
  compiled output is lost on `--force-recreate` or image pull.

If you want it to persist, uncomment the optional mount in
[docker-compose.heavy.yml](docker-compose.heavy.yml):

```yaml
- "./build/default:/app/public/default"
```

Convention: `./build/<themename>` on the host maps to
`/app/public/<themename>` in the container — one subdirectory per
theme, all grouped under `./build/`.

The entrypoint seeds an empty `./build/default/` from the image's
baked-in snapshot at `/app/default/build`, so the theme keeps working
on first start. On image updates the bundle is refreshed automatically
unless you set `PAYMENTER_SKIP_DEFAULT=true`.

For **custom themes** that set their own `buildDirectory` (e.g.
`'mytheme/'`), add a parallel mount such as
`- "./build/mytheme:/app/public/mytheme"`. There is no automatic
seeding for those — run `npm run build` once after enabling the mount.

## Migration notes for existing users

1. Update your `docker-compose.yml` to the new version from this PR.
2. Stop the stack and remove the old `app` named volume:

   ```bash
   docker compose down
   docker volume rm <project>_app
   ```
3. Pull and start as usual:

   ```bash
   docker compose pull
   docker compose up -d
   ```
