### PR TITLE
fix: prevent 500 error when cancellation reason exceeds 255 characters

### DIFF
--- a/app/Livewire/Services/Cancel.php
+++ b/app/Livewire/Services/Cancel.php
@@ -14,7 +14,7 @@ class Cancel extends Component
     #[Validate('required|in:end_of_period,immediate')]
     public $type = 'end_of_period';
 
-    #[Validate('required')]
+    #[Validate('required|max:255')]
     public $reason = '';
 
     public function cancelService()

--- a/themes/default/views/services/cancel.blade.php
+++ b/themes/default/views/services/cancel.blade.php
@@ -6,7 +6,7 @@
         <option value="immediate">{{ __('services.cancel_immediate') }}</option>
     </x-form.select>
 
-    <x-form.textarea name="reason" label="{{ __('services.cancel_reason') }}" required wire:model="reason" />
+    <x-form.textarea name="reason" label="{{ __('services.cancel_reason') }}" maxlength="255" required wire:model="reason" />
 
     <!-- Show you'll lose data warning if immediate cancellation is selected -->
     <template x-if="$wire.type === 'immediate'">


### PR DESCRIPTION
  ## Problem

  When a customer cancels a service and enters a cancellation reason longer
  than 255 characters, the request fails with a **500 error** instead of a
  friendly validation message.

  The `service_cancellations.reason` column is `varchar(255)`, but the
  customer-facing form (`App\Livewire\Services\Cancel`) only validates the
  field as `required` — there is no length limit. On PostgreSQL the insert
  throws:

  SQLSTATE[22001]: String data, right truncated: 7 ERROR: value too long
  for type character varying(255)

  (MySQL in non-strict mode would silently truncate the reason instead.)

  ## Root cause

  The customer self-service cancellation path is the only `reason` writer
  that lacks a length guard. The other two paths already cap it to 255:

  - Admin resource: `TextInput::make('reason')->maxLength(255)`
    (`ServiceCancellationResource.php`)
  - WHMCS importer: `mb_substr($record['reason'], 0, 255)`
    (`ImportFromWhmcs.php`)

  ## Changes

  - `app/Livewire/Services/Cancel.php`: change the `reason` validation rule
    from `required` to `required|max:255`, so an over-length reason returns
    a validation error rather than a 500.
  - `themes/default/views/services/cancel.blade.php`: add `maxlength="255"`
    to the reason textarea as a front-end safeguard.

  No database/schema change is required — this aligns the customer path with
  the existing 255-character limit used everywhere else.

  ## How to reproduce

  1. As a customer, open the cancellation page for an active service.
  2. Enter a reason with more than 255 characters.
  3. Submit — before this fix the request 500s; after, a validation message
     is shown.