### PR TITLE
fix(cart): Checkout coupon object access

### DIFF
--- a/app/Livewire/Cart.php
+++ b/app/Livewire/Cart.php
@@ -171,7 +171,7 @@ class Cart extends Component
             // Create the services
             foreach ($cart->items as $item) {
                 // Is it a lifetime coupon, then we can adjust the price of the service
-                if ($this->coupon && ($this->coupon->recurring === null || (int) $this->coupon->recurring == 1)) {
+                if (is_object($this->coupon) && ($this->coupon->recurring === null || (int) $this->coupon->recurring == 1)) {
                     // Apply coupon only to first billing cycle (use original price for recurring)
                     $price = $item->price->original_price;
                 } else {


### PR DESCRIPTION
This PR fixes an error during checkout when a customer types into the promo code field but does not apply the coupon before submitting the cart.

In that state, the Livewire `coupon` property can still contain the raw input string. `checkout()` then attempts to read `$this->coupon->recurring`, which throws because the value is not a coupon object.

**Fix**:
Only read `recurring` when `$this->coupon` is an object. A typed-but-unapplied promo code should behave as no applied coupon, matching the cart's `coupon_id` state.

**Reproducibility**:
Reproduced the issue by entering text in the promo code box without applying it, then checking out. The checkout no longer errors after this guard.