### PR TITLE
Fix Stripe 100x overcharge for zero-decimal currencies (JPY, KRW, ...)

### DIFF
--- a/extensions/Gateways/Stripe/Stripe.php
+++ b/extensions/Gateways/Stripe/Stripe.php
@@ -175,11 +175,47 @@ class Stripe extends Gateway
         ])->asForm()->$method('https://api.stripe.com/v1' . $url, $data)->throw()->object();
     }
 
+    /**
+     * Currencies that Stripe expects in the major unit (no minor unit / "zero-decimal").
+     * For these the amount must NOT be multiplied by 100.
+     *
+     * @see https://docs.stripe.com/currencies#zero-decimal
+     */
+    private const ZERO_DECIMAL_CURRENCIES = [
+        'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA',
+        'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF',
+    ];
+
+    /**
+     * The factor between a human-readable amount and the smallest unit Stripe expects.
+     * 1 for zero-decimal currencies (e.g. JPY), 100 for everything else.
+     */
+    private function currencyFactor($currency): int
+    {
+        return in_array(strtoupper((string) $currency), self::ZERO_DECIMAL_CURRENCIES, true) ? 1 : 100;
+    }
+
+    /**
+     * Convert a human-readable amount into the smallest unit Stripe expects.
+     */
+    private function toStripeAmount($amount, $currency): int
+    {
+        return (int) round($amount * $this->currencyFactor($currency));
+    }
+
+    /**
+     * Convert a Stripe smallest-unit amount back into a human-readable amount.
+     */
+    private function fromStripeAmount($amount, $currency): float
+    {
+        return $amount / $this->currencyFactor($currency);
+    }
+
     public function pay($invoice, $total)
     {
         $intentData = [
             'description' => __('invoices.payment_for_invoice', ['number' => $invoice->number ?? $invoice->id]),
-            'amount' => $total * 100,
+            'amount' => $this->toStripeAmount($total, $invoice->currency_code),
             'currency' => $invoice->currency_code,
             'automatic_payment_methods' => ['enabled' => 'true'],
             'metadata' => ['invoice_id' => $invoice->id],
@@ -216,7 +252,7 @@ class Stripe extends Gateway
                 if (!isset($paymentIntent->metadata->invoice_id)) {
                     break;
                 }
-                ExtensionHelper::addProcessingPayment($paymentIntent->metadata->invoice_id, 'Stripe', $paymentIntent->amount / 100, null, $paymentIntent->id);
+                ExtensionHelper::addProcessingPayment($paymentIntent->metadata->invoice_id, 'Stripe', $this->fromStripeAmount($paymentIntent->amount, $paymentIntent->currency), null, $paymentIntent->id);
                 break;
                 // Normal payment
             case 'payment_intent.succeeded':
@@ -224,14 +260,14 @@ class Stripe extends Gateway
                 if (!isset($paymentIntent->metadata->invoice_id)) {
                     break;
                 }
-                ExtensionHelper::addPayment($paymentIntent->metadata->invoice_id, 'Stripe', $paymentIntent->amount / 100, null, $paymentIntent->id);
+                ExtensionHelper::addPayment($paymentIntent->metadata->invoice_id, 'Stripe', $this->fromStripeAmount($paymentIntent->amount, $paymentIntent->currency), null, $paymentIntent->id);
                 break;
             case 'payment_intent.payment_failed':
                 $paymentIntent = $event->data->object; // contains a StripePaymentIntent
                 if (!isset($paymentIntent->metadata->invoice_id)) {
                     break;
                 }
-                ExtensionHelper::addFailedPayment($paymentIntent->metadata->invoice_id, 'Stripe', $paymentIntent->amount / 100, null, $paymentIntent->id);
+                ExtensionHelper::addFailedPayment($paymentIntent->metadata->invoice_id, 'Stripe', $this->fromStripeAmount($paymentIntent->amount, $paymentIntent->currency), null, $paymentIntent->id);
                 break;
             case 'charge.updated':
                 $charge = $event->data->object; // contains a StripeCharge
@@ -243,7 +279,8 @@ class Stripe extends Gateway
                 $fee = 0;
                 if ($charge->balance_transaction) {
                     $balanceTransaction = $this->request('get', '/balance_transactions/' . $charge->balance_transaction);
-                    $fee = $balanceTransaction->fee / 100;
+                    // Fees are charged in the balance transaction's own currency
+                    $fee = $this->fromStripeAmount($balanceTransaction->fee, $balanceTransaction->currency);
                 }
                 ExtensionHelper::addPaymentFee($charge->payment_intent, $fee);
 
@@ -300,7 +337,7 @@ class Stripe extends Gateway
                         break;
                     }
 
-                    ExtensionHelper::addPayment($invoiceModel->id, 'Stripe', $invoice->amount_paid / 100, null, $paymentIntent->payment->payment_intent);
+                    ExtensionHelper::addPayment($invoiceModel->id, 'Stripe', $this->fromStripeAmount($invoice->amount_paid, $invoice->currency), null, $paymentIntent->payment->payment_intent);
                 }
                 break;
             default:
@@ -357,7 +394,7 @@ class Stripe extends Gateway
                             'price_data' => [
                                 'currency' => $invoice->currency_code,
                                 'product' => $stripeProduct->id,
-                                'unit_amount' => $item->price * 100,
+                                'unit_amount' => $this->toStripeAmount($item->price, $invoice->currency_code),
                                 'recurring' => [
                                     'interval' => $service->plan->billing_unit,
                                     'interval_count' => $service->plan->billing_period,
@@ -379,7 +416,7 @@ class Stripe extends Gateway
                         'price_data' => [
                             'currency' => $invoice->currency_code,
                             'product' => $stripeProduct->id,
-                            'unit_amount' => ($service->price * $service->quantity) * 100,
+                            'unit_amount' => $this->toStripeAmount($service->price * $service->quantity, $invoice->currency_code),
                             'recurring' => [
                                 'interval' => $service->plan->billing_unit,
                                 'interval_count' => $service->plan->billing_period,
@@ -443,7 +480,7 @@ class Stripe extends Gateway
                 $key = count($phases) - 1;
                 $phases[$key]['items'][0]->price_data = [
                     'currency' => $service->currency->code,
-                    'unit_amount' => $service->price * 100,
+                    'unit_amount' => $this->toStripeAmount($service->price, $service->currency->code),
                     'product' => $stripeProduct->id,
                     'recurring' => [
                         'interval' => $service->plan->billing_unit,
@@ -467,7 +504,7 @@ class Stripe extends Gateway
                 $this->request('post', '/subscription_items/' . $item->id, [
                     'price_data' => [
                         'currency' => $service->currency->code,
-                        'unit_amount' => $service->price * 100,
+                        'unit_amount' => $this->toStripeAmount($service->price, $service->currency->code),
                         'product' => $item->price->product,
                         'recurring' => [
                             'interval' => $service->plan->billing_unit,
@@ -498,7 +535,7 @@ class Stripe extends Gateway
                 $this->request('post', '/subscription_items/' . $item->id, [
                     'price_data' => [
                         'currency' => $service->currency->code,
-                        'unit_amount' => $service->price * 100,
+                        'unit_amount' => $this->toStripeAmount($service->price, $service->currency->code),
                         'product' => $item->price->product,
                         'recurring' => [
                             'interval' => $service->plan->billing_unit,
@@ -758,7 +795,7 @@ class Stripe extends Gateway
         // Create payment intent
         try {
             $intent = $this->request('post', '/payment_intents', [
-                'amount' => $amount * 100,
+                'amount' => $this->toStripeAmount($amount, $invoice->currency_code),
                 'currency' => $invoice->currency_code,
                 'customer' => $customer->id,
                 'payment_method' => $billingAgreement->external_reference,


### PR DESCRIPTION
# PR: Fix Stripe 100× overcharge for zero-decimal currencies

Fixes the issue where the Stripe gateway charges 100× the intended amount for
zero-decimal currencies such as `JPY` and `KRW` (see
[`stripe-zero-decimal-currency-issue.md`](./stripe-zero-decimal-currency-issue.md)).

## Problem

The Stripe gateway unconditionally multiplied every amount by `100` (and divided
incoming webhook amounts by `100`) to convert to Stripe's smallest currency
unit. This is correct for two-decimal currencies (USD cents, EUR cents) but
wrong for **zero-decimal currencies**, which Stripe expects in the major unit.

Result: a `¥80` invoice created a PaymentIntent for `8000` → the customer was
charged ¥8000.

## Fix

Added a small currency-aware conversion layer to
`extensions/Gateways/Stripe/Stripe.php` and routed all amount conversions
through it:

- `ZERO_DECIMAL_CURRENCIES` — Stripe's
  [zero-decimal currency list](https://docs.stripe.com/currencies#zero-decimal).
- `currencyFactor($currency)` — returns `1` for zero-decimal currencies, `100`
  otherwise.
- `toStripeAmount($amount, $currency)` — human amount → Stripe smallest unit
  (`(int) round(...)`).
- `fromStripeAmount($amount, $currency)` — Stripe smallest unit → human amount.

All hardcoded `* 100` / `/ 100` sites were replaced:

| Location                              | Before                         | After                                            |
| ------------------------------------- | ------------------------------ | ------------------------------------------------ |
| `pay()`                               | `$total * 100`                 | `toStripeAmount($total, $invoice->currency_code)`|
| `charge()` (billing agreement)        | `$amount * 100`                | `toStripeAmount($amount, $invoice->currency_code)`|
| Subscription `unit_amount` (×5)       | `$price * 100`                 | `toStripeAmount($price, $currency)`              |
| Webhook processing/succeeded/failed   | `$intent->amount / 100`        | `fromStripeAmount($intent->amount, $intent->currency)` |
| Webhook fee (`charge.updated`)        | `$balanceTransaction->fee/100` | `fromStripeAmount($bt->fee, $bt->currency)`      |
| Webhook subscription invoice paid     | `$invoice->amount_paid / 100`  | `fromStripeAmount($invoice->amount_paid, $invoice->currency)` |

For every two-decimal currency the behaviour is unchanged (factor stays `100`).

## Testing

- `php -l extensions/Gateways/Stripe/Stripe.php` — no syntax errors.
- Manual: create a `JPY` product at `80`, pay via Stripe, confirm the
  PaymentIntent amount in the Stripe dashboard is `80` (not `8000`).
- Regression: confirm a `USD`/`EUR` invoice still sends the amount in cents.

## Notes for reviewers / deployers

- Run `php artisan queue:restart` (and restart PHP-FPM / workers if OPcache is
  enabled) to load the change.
- Existing unpaid invoices and existing Stripe subscriptions created before this
  fix may still carry the old 100× amounts and should be re-checked.
- Three-decimal currencies (BHD, JOD, KWD, OMR, TND) are still treated as
  two-decimal; out of scope for this fix but worth a follow-up if those
  currencies are used.
