### PR TITLE
Confirm payment on return from redirect checkout (fixes pending invoices without webhook)

### DIFF
--- a/app/Classes/Extension/Gateway.php
+++ b/app/Classes/Extension/Gateway.php
@@ -60,4 +60,18 @@ abstract class Gateway extends Extension
     {
         throw new \Exception('Not implemented');
     }
+
+    /**
+     * Verify a payment for the given invoice directly with the gateway.
+     *
+     * Called when the customer returns from an off-site / redirect checkout, so
+     * that activation does not depend on an asynchronous webhook (which may be
+     * unreachable in local / test environments). Implementations decide for
+     * themselves — based on the current request — whether they apply, and must
+     * be idempotent: recording the same payment again is safe. Default: no-op.
+     */
+    public function checkPayment(Invoice $invoice): void
+    {
+        // No-op by default; gateways that redirect off-site should override this.
+    }
 }

--- a/app/Helpers/ExtensionHelper.php
+++ b/app/Helpers/ExtensionHelper.php
@@ -406,6 +406,21 @@ class ExtensionHelper
         return self::getExtension('gateway', $gateway->extension, $gateway->settings)->charge($invoice, $invoice->remaining, $billingAgreement);
     }
 
+    /**
+     * Ask every gateway to verify whether the given invoice has been paid.
+     *
+     * Used when the customer returns from a redirect checkout to confirm the
+     * payment directly with the gateway, without waiting for a webhook. Each
+     * gateway decides for itself (based on the current request) whether it
+     * applies, so this is safe to call for any pending invoice.
+     */
+    public static function checkPayment(Invoice $invoice): void
+    {
+        foreach (Gateway::with('settings')->get() as $gateway) {
+            self::getExtension('gateway', $gateway->extension, $gateway->settings)->checkPayment($invoice);
+        }
+    }
+
     public static function getBillingAgreementGateways()
     {
         $gateways = [];

--- a/app/Livewire/Invoices/Show.php
+++ b/app/Livewire/Invoices/Show.php
@@ -36,7 +36,15 @@ class Show extends Component
     public function mount()
     {
         if (Request::has('checkPayment') && $this->invoice->status === 'pending') {
-            $this->checkPayment = true;
+            // Returning from an off-site checkout: confirm the payment directly
+            // with the gateway so activation doesn't depend on a webhook (which
+            // may not reach local / test environments).
+            ExtensionHelper::checkPayment($this->invoice);
+            $this->invoice->refresh();
+
+            if ($this->invoice->status === 'pending') {
+                $this->checkPayment = true;
+            }
         }
         if ($this->invoice->transactions()->where('status', InvoiceTransactionStatus::Processing)->exists()) {
             $this->checkPayment = true;

--- a/extensions/Gateways/Stripe/Stripe.php
+++ b/extensions/Gateways/Stripe/Stripe.php
@@ -175,11 +175,47 @@ class Stripe extends Gateway
         ])->asForm()->$method('https://api.stripe.com/v1' . $url, $data)->throw()->object();
     }
 
+    /**
+     * Currencies that Stripe expects in the major unit (no minor unit / "zero-decimal").
+     * For these the amount must NOT be multiplied by 100.
+     *
+     * @see https://docs.stripe.com/currencies#zero-decimal
+     */
+    private const ZERO_DECIMAL_CURRENCIES = [
+        'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA',
+        'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF',
+    ];
+
+    /**
+     * The factor between a human-readable amount and the smallest unit Stripe expects.
+     * 1 for zero-decimal currencies (e.g. JPY), 100 for everything else.
+     */
+    private function currencyFactor($currency): int
+    {
+        return in_array(strtoupper((string) $currency), self::ZERO_DECIMAL_CURRENCIES, true) ? 1 : 100;
+    }
+
+    /**
+     * Convert a human-readable amount into the smallest unit Stripe expects.
+     */
+    private function toStripeAmount($amount, $currency): int
+    {
+        return (int) round($amount * $this->currencyFactor($currency));
+    }
+
+    /**
+     * Convert a Stripe smallest-unit amount back into a human-readable amount.
+     */
+    private function fromStripeAmount($amount, $currency): float
+    {
+        return $amount / $this->currencyFactor($currency);
+    }
+
     public function pay($invoice, $total)
     {
         $intentData = [
             'description' => __('invoices.payment_for_invoice', ['number' => $invoice->number ?? $invoice->id]),
-            'amount' => $total * 100,
+            'amount' => $this->toStripeAmount($total, $invoice->currency_code),
             'currency' => $invoice->currency_code,
             'automatic_payment_methods' => ['enabled' => 'true'],
             'metadata' => ['invoice_id' => $invoice->id],
@@ -216,7 +252,7 @@ class Stripe extends Gateway
                 if (!isset($paymentIntent->metadata->invoice_id)) {
                     break;
                 }
-                ExtensionHelper::addProcessingPayment($paymentIntent->metadata->invoice_id, 'Stripe', $paymentIntent->amount / 100, null, $paymentIntent->id);
+                ExtensionHelper::addProcessingPayment($paymentIntent->metadata->invoice_id, 'Stripe', $this->fromStripeAmount($paymentIntent->amount, $paymentIntent->currency), null, $paymentIntent->id);
                 break;
                 // Normal payment
             case 'payment_intent.succeeded':
@@ -224,14 +260,14 @@ class Stripe extends Gateway
                 if (!isset($paymentIntent->metadata->invoice_id)) {
                     break;
                 }
-                ExtensionHelper::addPayment($paymentIntent->metadata->invoice_id, 'Stripe', $paymentIntent->amount / 100, null, $paymentIntent->id);
+                ExtensionHelper::addPayment($paymentIntent->metadata->invoice_id, 'Stripe', $this->fromStripeAmount($paymentIntent->amount, $paymentIntent->currency), null, $paymentIntent->id);
                 break;
             case 'payment_intent.payment_failed':
                 $paymentIntent = $event->data->object; // contains a StripePaymentIntent
                 if (!isset($paymentIntent->metadata->invoice_id)) {
                     break;
                 }
-                ExtensionHelper::addFailedPayment($paymentIntent->metadata->invoice_id, 'Stripe', $paymentIntent->amount / 100, null, $paymentIntent->id);
+                ExtensionHelper::addFailedPayment($paymentIntent->metadata->invoice_id, 'Stripe', $this->fromStripeAmount($paymentIntent->amount, $paymentIntent->currency), null, $paymentIntent->id);
                 break;
             case 'charge.updated':
                 $charge = $event->data->object; // contains a StripeCharge
@@ -243,7 +279,8 @@ class Stripe extends Gateway
                 $fee = 0;
                 if ($charge->balance_transaction) {
                     $balanceTransaction = $this->request('get', '/balance_transactions/' . $charge->balance_transaction);
-                    $fee = $balanceTransaction->fee / 100;
+                    // Fees are charged in the balance transaction's own currency
+                    $fee = $this->fromStripeAmount($balanceTransaction->fee, $balanceTransaction->currency);
                 }
                 ExtensionHelper::addPaymentFee($charge->payment_intent, $fee);
 
@@ -300,7 +337,7 @@ class Stripe extends Gateway
                         break;
                     }
 
-                    ExtensionHelper::addPayment($invoiceModel->id, 'Stripe', $invoice->amount_paid / 100, null, $paymentIntent->payment->payment_intent);
+                    ExtensionHelper::addPayment($invoiceModel->id, 'Stripe', $this->fromStripeAmount($invoice->amount_paid, $invoice->currency), null, $paymentIntent->payment->payment_intent);
                 }
                 break;
             default:
@@ -357,7 +394,7 @@ class Stripe extends Gateway
                             'price_data' => [
                                 'currency' => $invoice->currency_code,
                                 'product' => $stripeProduct->id,
-                                'unit_amount' => $item->price * 100,
+                                'unit_amount' => $this->toStripeAmount($item->price, $invoice->currency_code),
                                 'recurring' => [
                                     'interval' => $service->plan->billing_unit,
                                     'interval_count' => $service->plan->billing_period,
@@ -379,7 +416,7 @@ class Stripe extends Gateway
                         'price_data' => [
                             'currency' => $invoice->currency_code,
                             'product' => $stripeProduct->id,
-                            'unit_amount' => ($service->price * $service->quantity) * 100,
+                            'unit_amount' => $this->toStripeAmount($service->price * $service->quantity, $invoice->currency_code),
                             'recurring' => [
                                 'interval' => $service->plan->billing_unit,
                                 'interval_count' => $service->plan->billing_period,
@@ -443,7 +480,7 @@ class Stripe extends Gateway
                 $key = count($phases) - 1;
                 $phases[$key]['items'][0]->price_data = [
                     'currency' => $service->currency->code,
-                    'unit_amount' => $service->price * 100,
+                    'unit_amount' => $this->toStripeAmount($service->price, $service->currency->code),
                     'product' => $stripeProduct->id,
                     'recurring' => [
                         'interval' => $service->plan->billing_unit,
@@ -467,7 +504,7 @@ class Stripe extends Gateway
                 $this->request('post', '/subscription_items/' . $item->id, [
                     'price_data' => [
                         'currency' => $service->currency->code,
-                        'unit_amount' => $service->price * 100,
+                        'unit_amount' => $this->toStripeAmount($service->price, $service->currency->code),
                         'product' => $item->price->product,
                         'recurring' => [
                             'interval' => $service->plan->billing_unit,
@@ -498,7 +535,7 @@ class Stripe extends Gateway
                 $this->request('post', '/subscription_items/' . $item->id, [
                     'price_data' => [
                         'currency' => $service->currency->code,
-                        'unit_amount' => $service->price * 100,
+                        'unit_amount' => $this->toStripeAmount($service->price, $service->currency->code),
                         'product' => $item->price->product,
                         'recurring' => [
                             'interval' => $service->plan->billing_unit,
@@ -758,7 +795,7 @@ class Stripe extends Gateway
         // Create payment intent
         try {
             $intent = $this->request('post', '/payment_intents', [
-                'amount' => $amount * 100,
+                'amount' => $this->toStripeAmount($amount, $invoice->currency_code),
                 'currency' => $invoice->currency_code,
                 'customer' => $customer->id,
                 'payment_method' => $billingAgreement->external_reference,

--- a/extensions/Gateways/Stripe/Stripe.php
+++ b/extensions/Gateways/Stripe/Stripe.php
@@ -237,6 +237,44 @@ class Stripe extends Gateway
         return view('gateways.stripe::pay', ['invoice' => $invoice, 'total' => $total, 'intent' => $intent, 'stripePublishableKey' => $this->config('stripe_publishable_key')]);
     }
 
+    /**
+     * Confirm a payment on return from Stripe's redirect checkout.
+     *
+     * Stripe appends `payment_intent` to the return URL, so we can verify the
+     * payment directly with the API instead of waiting for the webhook (which
+     * is unreachable in most local / test setups). Idempotent: addPayment is
+     * keyed by the PaymentIntent id, so a later webhook won't double-count it.
+     */
+    public function checkPayment(Invoice $invoice): void
+    {
+        $paymentIntentId = request()->input('payment_intent');
+        if (!$paymentIntentId) {
+            return;
+        }
+
+        try {
+            $paymentIntent = $this->request('get', '/payment_intents/' . $paymentIntentId);
+        } catch (Exception $e) {
+            return;
+        }
+
+        // Only act on an intent that actually belongs to this invoice
+        if (($paymentIntent->metadata->invoice_id ?? null) != $invoice->id) {
+            return;
+        }
+
+        $amount = $this->fromStripeAmount($paymentIntent->amount, $paymentIntent->currency);
+
+        switch ($paymentIntent->status) {
+            case 'succeeded':
+                ExtensionHelper::addPayment($invoice->id, 'Stripe', $amount, null, $paymentIntent->id);
+                break;
+            case 'processing':
+                ExtensionHelper::addProcessingPayment($invoice->id, 'Stripe', $amount, null, $paymentIntent->id);
+                break;
+        }
+    }
+
     public function webhook(Request $request)
     {
         if (!$this->isValidSignature($request->getContent(), $request->header('Stripe-Signature'), $this->config('stripe_webhook_secret'))) {


### PR DESCRIPTION
# PR: Confirm payment on return from redirect checkout (Stripe)

Fixes #1260 — invoices getting stuck in **pending** after a successful Stripe
payment when the webhook doesn't reach the app.

> **Note:** stacked on top of #1259 (zero-decimal currency fix) because
> `Stripe::checkPayment()` reuses its `fromStripeAmount()` helper for the amount
> conversion. Merge #1259 first; this PR's diff then reduces to just the changes
> below.

## Problem

Invoices were only marked paid (and their services provisioned) by the Stripe
webhook (`payment_intent.succeeded`). The return page only polled for a paid
status, so when the webhook was unreachable/unconfigured — the normal case in
local and test environments — a successful payment left the invoice pending and
the service un-provisioned forever.

## Fix

- **`app/Classes/Extension/Gateway.php`** — add a generic, default no-op
  `checkPayment(Invoice $invoice): void` hook. Gateways that redirect off-site
  can override it to confirm a payment directly with the provider on return.
- **`app/Helpers/ExtensionHelper.php`** — add `checkPayment(Invoice $invoice)`
  that asks every gateway to verify the invoice (each gateway decides, from the
  request, whether it applies).
- **`app/Livewire/Invoices/Show.php`** — on return (`?checkPayment=true`) for a
  pending invoice, call `ExtensionHelper::checkPayment()` and refresh before
  falling back to polling.
- **`extensions/Gateways/Stripe/Stripe.php`** — implement `checkPayment()`:
  read the `payment_intent` Stripe appends to the return URL, fetch the intent,
  verify `metadata.invoice_id` matches, then record the payment
  (`succeeded → addPayment`, `processing → addProcessingPayment`).

## Why it's safe

- **Idempotent**: `addPayment` is keyed by the PaymentIntent id
  (`updateOrCreate` on `transaction_id`), so a webhook arriving later updates the
  same transaction instead of creating a duplicate — no double-counting.
- **No extra API calls on normal loads**: Stripe's `checkPayment` returns early
  unless `payment_intent` is present in the request (i.e. only on return from
  the redirect).
- **Webhook unchanged**: still the production source of truth and a fallback.
- **Ownership check**: only acts on an intent whose `metadata.invoice_id`
  matches the invoice being viewed.

## Testing

- `php -l` on all four changed files — no syntax errors.
- Manual (Stripe test mode, no webhook): pay a pending invoice, get redirected
  back, confirm the invoice flips to paid and the service is provisioned
  immediately.
- Regression: pay with the webhook configured and confirm no duplicate
  transaction is created (return-path + webhook resolve to the same
  PaymentIntent id).
