### PR TITLE
fix: respect theme colors on plan select in checkout

### DIFF
--- a/themes/default/views/products/checkout.blade.php
+++ b/themes/default/views/products/checkout.blade.php
@@ -12,8 +12,7 @@
             </div>
         </div>
         @if ($product->availablePlans()->count() > 1)
-            <x-form.select wire:model.live="plan_id" class="text-white bg-primary-800 px-2.5 py-2.5 rounded-md w-full"
-                name="plan_id" label="Select a plan">
+            <x-form.select wire:model.live="plan_id" name="plan_id" label="Select a plan">
                 @foreach ($product->availablePlans() as $availablePlan)
                     <option value="{{ $availablePlan->id }}">
                         {{ $availablePlan->name }} -


### PR DESCRIPTION
The Select a plan dropdown on the product checkout page had `text-white bg-primary-800` hardcoded as inline classes. This forced a dark background and white text regardless of the active theme, so on the **light theme** the dropdown rendered white text on a near-white background — making the plan names unreadable.

This removes the hardcoded color classes so the `<x-form.select>` component falls back to its default styling, which already adapts to both light and dark themes.
