### PR TITLE
Add location catalog provider mapping

### DIFF
--- a/app/Admin/Resources/LocationGroupResource.php
+++ b/app/Admin/Resources/LocationGroupResource.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Admin\Resources;
+
+use App\Admin\Resources\LocationGroupResource\Pages\CreateLocationGroup;
+use App\Admin\Resources\LocationGroupResource\Pages\EditLocationGroup;
+use App\Admin\Resources\LocationGroupResource\Pages\ListLocationGroups;
+use App\Models\LocationGroup;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\KeyValue;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class LocationGroupResource extends Resource
+{
+    protected static ?string $model = LocationGroup::class;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Configuration';
+
+    protected static string|\BackedEnum|null $navigationIcon = 'ri-folder-6-line';
+
+    protected static string|\BackedEnum|null $activeNavigationIcon = 'ri-folder-6-fill';
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255)
+                    ->live(onBlur: true),
+                TextInput::make('code')
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true),
+                Select::make('parent_id')
+                    ->label('Parent Group')
+                    ->options(fn () => LocationGroup::query()->orderBy('sort_order')->orderBy('name')->pluck('name', 'id'))
+                    ->nullable()
+                    ->searchable()
+                    ->preload(),
+                Select::make('group_type')
+                    ->required()
+                    ->options(self::groupTypes())
+                    ->default(LocationGroup::TYPE_CUSTOM),
+                Select::make('status')
+                    ->required()
+                    ->options(self::statuses())
+                    ->default(LocationGroup::STATUS_ACTIVE),
+                TextInput::make('sort_order')
+                    ->numeric()
+                    ->default(0)
+                    ->required(),
+                CheckboxList::make('service_types')
+                    ->options(self::serviceTypes())
+                    ->columns(3),
+                KeyValue::make('metadata')
+                    ->columnSpanFull()
+                    ->keyLabel('Key')
+                    ->valueLabel('Value'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')->searchable()->sortable(),
+                TextColumn::make('code')->searchable()->sortable(),
+                TextColumn::make('parent.name')->label('Parent')->toggleable(),
+                TextColumn::make('group_type')->badge()->sortable(),
+                TextColumn::make('status')->badge()->sortable(),
+                TextColumn::make('options_count')->counts('options')->label('Items')->sortable(),
+                TextColumn::make('sort_order')->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')->options(self::statuses()),
+                SelectFilter::make('group_type')->options(self::groupTypes()),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make()
+                    ->modalDescription('Deleting a group keeps its location items and moves them to no group.'),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make()
+                        ->modalDescription('Deleting groups keeps their location items and moves them to no group.'),
+                ]),
+            ])
+            ->defaultSort(function (Builder $query): Builder {
+                return $query->orderBy('sort_order')->orderBy('name');
+            });
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListLocationGroups::route('/'),
+            'create' => CreateLocationGroup::route('/create'),
+            'edit' => EditLocationGroup::route('/{record}/edit'),
+        ];
+    }
+
+    public static function groupTypes(): array
+    {
+        return [
+            LocationGroup::TYPE_GEO => 'Geo',
+            LocationGroup::TYPE_REGION => 'Region',
+            LocationGroup::TYPE_COUNTRY_BUNDLE => 'Country Bundle',
+            LocationGroup::TYPE_ISP_BUNDLE => 'ISP Bundle',
+            LocationGroup::TYPE_CUSTOM => 'Custom',
+        ];
+    }
+
+    public static function statuses(): array
+    {
+        return [
+            LocationGroup::STATUS_ACTIVE => 'Active',
+            LocationGroup::STATUS_HIDDEN => 'Hidden',
+        ];
+    }
+
+    public static function serviceTypes(): array
+    {
+        return [
+            'vps' => 'VPS',
+            'proxy' => 'Proxy',
+            'vpn' => 'VPN',
+        ];
+    }
+}

--- a/app/Admin/Resources/LocationGroupResource/Pages/CreateLocationGroup.php
+++ b/app/Admin/Resources/LocationGroupResource/Pages/CreateLocationGroup.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Admin\Resources\LocationGroupResource\Pages;
+
+use App\Admin\Resources\LocationGroupResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateLocationGroup extends CreateRecord
+{
+    protected static string $resource = LocationGroupResource::class;
+}

--- a/app/Admin/Resources/LocationGroupResource/Pages/EditLocationGroup.php
+++ b/app/Admin/Resources/LocationGroupResource/Pages/EditLocationGroup.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Admin\Resources\LocationGroupResource\Pages;
+
+use App\Admin\Actions\AuditAction;
+use App\Admin\Resources\LocationGroupResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditLocationGroup extends EditRecord
+{
+    protected static string $resource = LocationGroupResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make()
+                ->modalDescription('Deleting this group keeps its location items and moves them to no group.'),
+            AuditAction::make(),
+        ];
+    }
+}

--- a/app/Admin/Resources/LocationGroupResource/Pages/ListLocationGroups.php
+++ b/app/Admin/Resources/LocationGroupResource/Pages/ListLocationGroups.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Admin\Resources\LocationGroupResource\Pages;
+
+use App\Admin\Resources\LocationGroupResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListLocationGroups extends ListRecords
+{
+    protected static string $resource = LocationGroupResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Admin/Resources/LocationOptionResource.php
+++ b/app/Admin/Resources/LocationOptionResource.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace App\Admin\Resources;
+
+use App\Admin\Resources\LocationOptionResource\Pages\CreateLocationOption;
+use App\Admin\Resources\LocationOptionResource\Pages\EditLocationOption;
+use App\Admin\Resources\LocationOptionResource\Pages\ListLocationOptions;
+use App\Models\LocationGroup;
+use App\Models\LocationOption;
+use Filament\Actions\BulkAction;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\KeyValue;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Str;
+
+class LocationOptionResource extends Resource
+{
+    protected static ?string $model = LocationOption::class;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Configuration';
+
+    protected static string|\BackedEnum|null $navigationIcon = 'ri-map-pin-line';
+
+    protected static string|\BackedEnum|null $activeNavigationIcon = 'ri-map-pin-fill';
+
+    protected static ?string $recordTitleAttribute = 'display_name';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('display_name')
+                    ->required()
+                    ->maxLength(255)
+                    ->live(onBlur: true)
+                    ->afterStateUpdated(function (Get $get, Set $set, ?string $old, ?string $state) {
+                        if (($get('code') ?? '') !== Str::slug($old)) {
+                            return;
+                        }
+
+                        $set('code', Str::slug($state));
+                    }),
+                TextInput::make('code')
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true),
+                Select::make('primary_group_id')
+                    ->label('Primary Group')
+                    ->relationship('primaryGroup', 'name')
+                    ->searchable()
+                    ->preload(),
+                TextInput::make('legacy_id')->numeric(),
+                Select::make('option_type')
+                    ->required()
+                    ->options(self::optionTypes())
+                    ->default(LocationOption::TYPE_GEO)
+                    ->live(),
+                TextInput::make('place_country_iso2')
+                    ->label('Country ISO2')
+                    ->maxLength(2),
+                TextInput::make('place_subdivision_code')
+                    ->label('Subdivision Code')
+                    ->maxLength(255),
+                Select::make('network_type')
+                    ->options(self::networkTypes())
+                    ->visible(fn (Get $get): bool => in_array($get('option_type'), [LocationOption::TYPE_NETWORK_POOL, LocationOption::TYPE_ISP_POOL])),
+                TextInput::make('isp_name')
+                    ->visible(fn (Get $get): bool => $get('option_type') === LocationOption::TYPE_ISP_POOL),
+                Select::make('selection_policy')
+                    ->required()
+                    ->options(self::selectionPolicies())
+                    ->default(LocationOption::POLICY_FIXED),
+                Select::make('status')
+                    ->required()
+                    ->options(self::statuses())
+                    ->default(LocationOption::STATUS_ACTIVE),
+                TextInput::make('sort_order')
+                    ->numeric()
+                    ->default(0)
+                    ->required(),
+                CheckboxList::make('service_types')
+                    ->options(LocationGroupResource::serviceTypes())
+                    ->columns(3),
+                KeyValue::make('metadata')
+                    ->columnSpanFull()
+                    ->keyLabel('Key')
+                    ->valueLabel('Value'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('display_name')->searchable()->sortable(),
+                TextColumn::make('code')->searchable()->toggleable(),
+                TextColumn::make('primaryGroup.name')->label('Group')->sortable(),
+                TextColumn::make('legacy_id')->label('Legacy ID')->sortable()->toggleable(),
+                TextColumn::make('option_type')->badge()->sortable(),
+                TextColumn::make('status')->badge()->sortable(),
+                TextColumn::make('sort_order')->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('primary_group_id')
+                    ->label('Group')
+                    ->relationship('primaryGroup', 'name')
+                    ->searchable()
+                    ->preload(),
+                SelectFilter::make('status')->options(self::statuses()),
+                SelectFilter::make('option_type')->options(self::optionTypes()),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    BulkAction::make('move_group')
+                        ->label('Move to Group')
+                        ->form([
+                            Select::make('primary_group_id')
+                                ->label('Target Group')
+                                ->options(fn () => LocationGroup::query()->orderBy('sort_order')->orderBy('name')->pluck('name', 'id'))
+                                ->nullable()
+                                ->searchable()
+                                ->preload(),
+                        ])
+                        ->action(fn (Collection $records, array $data) => $records->each->update([
+                            'primary_group_id' => $data['primary_group_id'] ?? null,
+                        ])),
+                    DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort(function (Builder $query): Builder {
+                return $query->orderBy('sort_order')->orderBy('display_name');
+            });
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListLocationOptions::route('/'),
+            'create' => CreateLocationOption::route('/create'),
+            'edit' => EditLocationOption::route('/{record}/edit'),
+        ];
+    }
+
+    public static function groupedOptions(): array
+    {
+        return LocationOption::query()
+            ->with('primaryGroup')
+            ->whereIn('status', [LocationOption::STATUS_ACTIVE, LocationOption::STATUS_HIDDEN])
+            ->orderBy('sort_order')
+            ->orderBy('display_name')
+            ->get()
+            ->groupBy(fn (LocationOption $option) => $option->primaryGroup?->name ?? 'Other')
+            ->map(fn ($options) => $options->pluck('display_name', 'id')->all())
+            ->all();
+    }
+
+    public static function optionTypes(): array
+    {
+        return [
+            LocationOption::TYPE_GEO => 'Geo',
+            LocationOption::TYPE_REGION => 'Region',
+            LocationOption::TYPE_SYNTHETIC_POOL => 'Synthetic Pool',
+            LocationOption::TYPE_ISP_POOL => 'ISP Pool',
+            LocationOption::TYPE_NETWORK_POOL => 'Network Pool',
+            LocationOption::TYPE_PROMO_POOL => 'Promo Pool',
+            LocationOption::TYPE_UNKNOWN => 'Unknown',
+        ];
+    }
+
+    public static function networkTypes(): array
+    {
+        return [
+            LocationOption::NETWORK_DATACENTER => 'Datacenter',
+            LocationOption::NETWORK_RESIDENTIAL => 'Residential',
+            LocationOption::NETWORK_MOBILE => 'Mobile',
+            LocationOption::NETWORK_VPN => 'VPN',
+            LocationOption::NETWORK_MIXED => 'Mixed',
+        ];
+    }
+
+    public static function selectionPolicies(): array
+    {
+        return [
+            LocationOption::POLICY_FIXED => 'Fixed',
+            LocationOption::POLICY_RANDOM => 'Random',
+            LocationOption::POLICY_PROVIDER_DECIDES => 'Provider Decides',
+        ];
+    }
+
+    public static function statuses(): array
+    {
+        return [
+            LocationOption::STATUS_ACTIVE => 'Active',
+            LocationOption::STATUS_HIDDEN => 'Hidden',
+            LocationOption::STATUS_DEPRECATED => 'Deprecated',
+        ];
+    }
+}

--- a/app/Admin/Resources/LocationOptionResource/Pages/CreateLocationOption.php
+++ b/app/Admin/Resources/LocationOptionResource/Pages/CreateLocationOption.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Admin\Resources\LocationOptionResource\Pages;
+
+use App\Admin\Resources\LocationOptionResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateLocationOption extends CreateRecord
+{
+    protected static string $resource = LocationOptionResource::class;
+}

--- a/app/Admin/Resources/LocationOptionResource/Pages/EditLocationOption.php
+++ b/app/Admin/Resources/LocationOptionResource/Pages/EditLocationOption.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Admin\Resources\LocationOptionResource\Pages;
+
+use App\Admin\Actions\AuditAction;
+use App\Admin\Resources\LocationOptionResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditLocationOption extends EditRecord
+{
+    protected static string $resource = LocationOptionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+            AuditAction::make(),
+        ];
+    }
+}

--- a/app/Admin/Resources/LocationOptionResource/Pages/ListLocationOptions.php
+++ b/app/Admin/Resources/LocationOptionResource/Pages/ListLocationOptions.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Admin\Resources\LocationOptionResource\Pages;
+
+use App\Admin\Resources\LocationOptionResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListLocationOptions extends ListRecords
+{
+    protected static string $resource = LocationOptionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Admin/Resources/ProductResource.php
+++ b/app/Admin/Resources/ProductResource.php
@@ -5,6 +5,7 @@ namespace App\Admin\Resources;
 use App\Admin\Resources\ProductResource\Pages\CreateProduct;
 use App\Admin\Resources\ProductResource\Pages\EditProduct;
 use App\Admin\Resources\ProductResource\Pages\ListProducts;
+use App\Admin\Resources\ProductResource\RelationManagers\LocationOfferingsRelationManager;
 use App\Classes\FilamentInput;
 use App\Helpers\ExtensionHelper;
 use App\Models\Currency;
@@ -323,6 +324,13 @@ class ProductResource extends Resource
                     ->orderBy('sort', 'asc');
             })
             ->defaultGroup('category.name');
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            LocationOfferingsRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Admin/Resources/ProductResource/RelationManagers/LocationOfferingsRelationManager.php
+++ b/app/Admin/Resources/ProductResource/RelationManagers/LocationOfferingsRelationManager.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Admin\Resources\ProductResource\RelationManagers;
+
+use App\Models\ProviderLocationOffering;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Support\RawJs;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class LocationOfferingsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'locationOfferings';
+
+    protected static ?string $title = 'Sellable Locations';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('provider_location_offering_id')
+                    ->label('Provider Location')
+                    ->options(fn () => $this->providerLocationOptions())
+                    ->searchable()
+                    ->required(),
+                Checkbox::make('enabled')
+                    ->default(true),
+                TextInput::make('price_delta')
+                    ->label('Price Delta')
+                    ->numeric()
+                    ->mask(RawJs::make(
+                        <<<'JS'
+                            $money($input, '.', '', 2)
+                        JS
+                    )),
+                TextInput::make('sort_order')
+                    ->numeric()
+                    ->default(0)
+                    ->required(),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('providerLocationOffering.locationOption.display_name')
+            ->columns([
+                TextColumn::make('providerLocationOffering.locationOption.display_name')
+                    ->label('Location')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('providerLocationOffering.locationOption.primaryGroup.name')
+                    ->label('Group')
+                    ->sortable(),
+                TextColumn::make('providerLocationOffering.service_type')
+                    ->label('Service Type')
+                    ->badge()
+                    ->sortable(),
+                TextColumn::make('providerLocationOffering.stock_state')
+                    ->label('Stock')
+                    ->badge()
+                    ->sortable(),
+                IconColumn::make('enabled')
+                    ->boolean(),
+                TextColumn::make('price_delta')
+                    ->label('Price Delta')
+                    ->toggleable(),
+                TextColumn::make('sort_order')
+                    ->sortable(),
+            ])
+            ->filters([
+                //
+            ])
+            ->headerActions([
+                CreateAction::make()
+                    ->hidden(fn () => $this->getOwnerRecord()->server_id === null),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    protected function providerLocationOptions(): array
+    {
+        $serverId = $this->getOwnerRecord()->server_id;
+
+        if (!$serverId) {
+            return [];
+        }
+
+        return ProviderLocationOffering::query()
+            ->with('locationOption.primaryGroup')
+            ->where('provider_id', $serverId)
+            ->where('enabled', true)
+            ->get()
+            ->groupBy(fn (ProviderLocationOffering $offering) => $offering->locationOption->primaryGroup?->name ?? 'Other')
+            ->map(fn ($offerings) => $offerings->mapWithKeys(fn (ProviderLocationOffering $offering) => [
+                $offering->id => $offering->locationOption->display_name . ' (' . strtoupper($offering->service_type) . ')',
+            ])->all())
+            ->all();
+    }
+}

--- a/app/Admin/Resources/ServerResource.php
+++ b/app/Admin/Resources/ServerResource.php
@@ -5,6 +5,7 @@ namespace App\Admin\Resources;
 use App\Admin\Resources\ServerResource\Pages\CreateServer;
 use App\Admin\Resources\ServerResource\Pages\EditServer;
 use App\Admin\Resources\ServerResource\Pages\ListServers;
+use App\Admin\Resources\ServerResource\RelationManagers\ProviderLocationOfferingsRelationManager;
 use App\Helpers\ExtensionHelper;
 use App\Models\Server;
 use Filament\Actions\Action;
@@ -130,7 +131,7 @@ class ServerResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            ProviderLocationOfferingsRelationManager::class,
         ];
     }
 

--- a/app/Admin/Resources/ServerResource/RelationManagers/ProviderLocationOfferingsRelationManager.php
+++ b/app/Admin/Resources/ServerResource/RelationManagers/ProviderLocationOfferingsRelationManager.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Admin\Resources\ServerResource\RelationManagers;
+
+use App\Admin\Resources\LocationGroupResource;
+use App\Admin\Resources\LocationOptionResource;
+use App\Models\ProviderLocationOffering;
+use App\Models\ProviderLocationTarget;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\KeyValue;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class ProviderLocationOfferingsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'providerLocationOfferings';
+
+    protected static ?string $title = 'Provider Locations';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('location_option_id')
+                    ->label('Location')
+                    ->options(fn () => LocationOptionResource::groupedOptions())
+                    ->searchable()
+                    ->required(),
+                Select::make('service_type')
+                    ->required()
+                    ->options(LocationGroupResource::serviceTypes())
+                    ->default(ProviderLocationOffering::SERVICE_VPS),
+                Checkbox::make('enabled')
+                    ->default(true),
+                Select::make('stock_state')
+                    ->required()
+                    ->options([
+                        ProviderLocationOffering::STOCK_UNKNOWN => 'Unknown',
+                        ProviderLocationOffering::STOCK_AVAILABLE => 'Available',
+                        ProviderLocationOffering::STOCK_LIMITED => 'Limited',
+                        ProviderLocationOffering::STOCK_UNAVAILABLE => 'Unavailable',
+                    ])
+                    ->default(ProviderLocationOffering::STOCK_UNKNOWN),
+                KeyValue::make('capabilities')
+                    ->columnSpanFull()
+                    ->keyLabel('Capability')
+                    ->valueLabel('Value'),
+                Repeater::make('targets')
+                    ->relationship('targets')
+                    ->label('Provider Targets')
+                    ->columnSpanFull()
+                    ->columns(2)
+                    ->defaultItems(1)
+                    ->schema([
+                        TextInput::make('external_location_id')
+                            ->label('External Location ID')
+                            ->maxLength(255),
+                        TextInput::make('external_location_code')
+                            ->label('External Location Code')
+                            ->maxLength(255),
+                        TextInput::make('external_name')
+                            ->label('External Name')
+                            ->maxLength(255),
+                        Select::make('status')
+                            ->required()
+                            ->options([
+                                ProviderLocationTarget::STATUS_ACTIVE => 'Active',
+                                ProviderLocationTarget::STATUS_DISABLED => 'Disabled',
+                            ])
+                            ->default(ProviderLocationTarget::STATUS_ACTIVE),
+                        TextInput::make('priority')
+                            ->numeric()
+                            ->default(0)
+                            ->required(),
+                        TextInput::make('weight')
+                            ->numeric()
+                            ->default(100)
+                            ->required(),
+                        KeyValue::make('raw_payload')
+                            ->columnSpanFull()
+                            ->keyLabel('Key')
+                            ->valueLabel('Value'),
+                    ]),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('locationOption.display_name')
+            ->columns([
+                TextColumn::make('locationOption.display_name')
+                    ->label('Location')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('locationOption.primaryGroup.name')
+                    ->label('Group')
+                    ->sortable(),
+                TextColumn::make('service_type')
+                    ->badge()
+                    ->sortable(),
+                IconColumn::make('enabled')
+                    ->boolean(),
+                TextColumn::make('stock_state')
+                    ->badge()
+                    ->sortable(),
+                TextColumn::make('targets.external_location_code')
+                    ->label('External Codes')
+                    ->listWithLineBreaks()
+                    ->toggleable(),
+            ])
+            ->filters([
+                SelectFilter::make('service_type')->options(LocationGroupResource::serviceTypes()),
+                SelectFilter::make('stock_state')->options([
+                    ProviderLocationOffering::STOCK_UNKNOWN => 'Unknown',
+                    ProviderLocationOffering::STOCK_AVAILABLE => 'Available',
+                    ProviderLocationOffering::STOCK_LIMITED => 'Limited',
+                    ProviderLocationOffering::STOCK_UNAVAILABLE => 'Unavailable',
+                ]),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Models/LocationGroup.php
+++ b/app/Models/LocationGroup.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use OwenIt\Auditing\Contracts\Auditable;
+
+class LocationGroup extends Model implements Auditable
+{
+    use HasFactory, Traits\Auditable;
+
+    public const TYPE_GEO = 'geo';
+
+    public const TYPE_REGION = 'region';
+
+    public const TYPE_COUNTRY_BUNDLE = 'country_bundle';
+
+    public const TYPE_ISP_BUNDLE = 'isp_bundle';
+
+    public const TYPE_CUSTOM = 'custom';
+
+    public const STATUS_ACTIVE = 'active';
+
+    public const STATUS_HIDDEN = 'hidden';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'service_types' => 'array',
+        'metadata' => 'array',
+    ];
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(LocationGroup::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(LocationGroup::class, 'parent_id')->orderBy('sort_order')->orderBy('name');
+    }
+
+    public function options(): HasMany
+    {
+        return $this->hasMany(LocationOption::class, 'primary_group_id')->orderBy('sort_order')->orderBy('display_name');
+    }
+}

--- a/app/Models/LocationOption.php
+++ b/app/Models/LocationOption.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use OwenIt\Auditing\Contracts\Auditable;
+
+class LocationOption extends Model implements Auditable
+{
+    use HasFactory, Traits\Auditable;
+
+    public const TYPE_GEO = 'geo';
+
+    public const TYPE_REGION = 'region';
+
+    public const TYPE_SYNTHETIC_POOL = 'synthetic_pool';
+
+    public const TYPE_ISP_POOL = 'isp_pool';
+
+    public const TYPE_NETWORK_POOL = 'network_pool';
+
+    public const TYPE_PROMO_POOL = 'promo_pool';
+
+    public const TYPE_UNKNOWN = 'unknown';
+
+    public const NETWORK_DATACENTER = 'datacenter';
+
+    public const NETWORK_RESIDENTIAL = 'residential';
+
+    public const NETWORK_MOBILE = 'mobile';
+
+    public const NETWORK_VPN = 'vpn';
+
+    public const NETWORK_MIXED = 'mixed';
+
+    public const POLICY_FIXED = 'fixed';
+
+    public const POLICY_RANDOM = 'random';
+
+    public const POLICY_PROVIDER_DECIDES = 'provider_decides';
+
+    public const STATUS_ACTIVE = 'active';
+
+    public const STATUS_HIDDEN = 'hidden';
+
+    public const STATUS_DEPRECATED = 'deprecated';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'legacy_id' => 'integer',
+        'service_types' => 'array',
+        'metadata' => 'array',
+    ];
+
+    public function primaryGroup(): BelongsTo
+    {
+        return $this->belongsTo(LocationGroup::class, 'primary_group_id');
+    }
+
+    public function providerLocationOfferings(): HasMany
+    {
+        return $this->hasMany(ProviderLocationOffering::class);
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -55,6 +55,11 @@ class Product extends Model implements Auditable
         return $this->hasMany(Service::class);
     }
 
+    public function locationOfferings(): HasMany
+    {
+        return $this->hasMany(ProductLocationOffering::class)->orderBy('sort_order');
+    }
+
     /**
      * Get the settings of the product.
      */

--- a/app/Models/ProductLocationOffering.php
+++ b/app/Models/ProductLocationOffering.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use OwenIt\Auditing\Contracts\Auditable;
+
+class ProductLocationOffering extends Model implements Auditable
+{
+    use HasFactory, Traits\Auditable;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'enabled' => 'boolean',
+        'price_delta' => 'decimal:2',
+    ];
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function providerLocationOffering(): BelongsTo
+    {
+        return $this->belongsTo(ProviderLocationOffering::class);
+    }
+}

--- a/app/Models/ProviderLocationOffering.php
+++ b/app/Models/ProviderLocationOffering.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use OwenIt\Auditing\Contracts\Auditable;
+
+class ProviderLocationOffering extends Model implements Auditable
+{
+    use HasFactory, Traits\Auditable;
+
+    public const SERVICE_VPS = 'vps';
+
+    public const SERVICE_PROXY = 'proxy';
+
+    public const SERVICE_VPN = 'vpn';
+
+    public const STOCK_UNKNOWN = 'unknown';
+
+    public const STOCK_AVAILABLE = 'available';
+
+    public const STOCK_LIMITED = 'limited';
+
+    public const STOCK_UNAVAILABLE = 'unavailable';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'enabled' => 'boolean',
+        'capabilities' => 'array',
+        'last_synced_at' => 'datetime',
+    ];
+
+    public function provider(): BelongsTo
+    {
+        return $this->belongsTo(Server::class, 'provider_id');
+    }
+
+    public function locationOption(): BelongsTo
+    {
+        return $this->belongsTo(LocationOption::class);
+    }
+
+    public function targets(): HasMany
+    {
+        return $this->hasMany(ProviderLocationTarget::class)->orderByDesc('priority')->orderByDesc('weight');
+    }
+
+    public function productLocationOfferings(): HasMany
+    {
+        return $this->hasMany(ProductLocationOffering::class);
+    }
+}

--- a/app/Models/ProviderLocationTarget.php
+++ b/app/Models/ProviderLocationTarget.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use OwenIt\Auditing\Contracts\Auditable;
+
+class ProviderLocationTarget extends Model implements Auditable
+{
+    use HasFactory, Traits\Auditable;
+
+    public const STATUS_ACTIVE = 'active';
+
+    public const STATUS_DISABLED = 'disabled';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'raw_payload' => 'array',
+    ];
+
+    public function providerLocationOffering(): BelongsTo
+    {
+        return $this->belongsTo(ProviderLocationOffering::class);
+    }
+}

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
 class Server extends Extension
 {
     protected $table = 'extensions';
@@ -9,5 +11,10 @@ class Server extends Extension
     public function newQuery($excludeDeleted = true)
     {
         return parent::newQuery($excludeDeleted)->where('type', 'server');
+    }
+
+    public function providerLocationOfferings(): HasMany
+    {
+        return $this->hasMany(ProviderLocationOffering::class, 'provider_id')->orderBy('service_type');
     }
 }

--- a/app/Policies/LocationGroupPolicy.php
+++ b/app/Policies/LocationGroupPolicy.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\LocationGroup;
+use App\Models\User;
+
+class LocationGroupPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->hasPermission('admin.location_groups.viewAny');
+    }
+
+    public function view(User $user, LocationGroup $locationGroup): bool
+    {
+        return $user->hasPermission('admin.location_groups.view');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->hasPermission('admin.location_groups.create');
+    }
+
+    public function update(User $user, LocationGroup $locationGroup): bool
+    {
+        return $user->hasPermission('admin.location_groups.update');
+    }
+
+    public function delete(User $user, LocationGroup $locationGroup): bool
+    {
+        return $user->hasPermission('admin.location_groups.delete');
+    }
+
+    public function deleteAny(User $user): bool
+    {
+        return $user->hasPermission('admin.location_groups.deleteAny');
+    }
+}

--- a/app/Policies/LocationOptionPolicy.php
+++ b/app/Policies/LocationOptionPolicy.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\LocationOption;
+use App\Models\User;
+
+class LocationOptionPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->hasPermission('admin.location_options.viewAny');
+    }
+
+    public function view(User $user, LocationOption $locationOption): bool
+    {
+        return $user->hasPermission('admin.location_options.view');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->hasPermission('admin.location_options.create');
+    }
+
+    public function update(User $user, LocationOption $locationOption): bool
+    {
+        return $user->hasPermission('admin.location_options.update');
+    }
+
+    public function delete(User $user, LocationOption $locationOption): bool
+    {
+        return $user->hasPermission('admin.location_options.delete');
+    }
+
+    public function deleteAny(User $user): bool
+    {
+        return $user->hasPermission('admin.location_options.deleteAny');
+    }
+}

--- a/app/Services/LocationAvailabilityService.php
+++ b/app/Services/LocationAvailabilityService.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\LocationOption;
+use App\Models\Product;
+use App\Models\ProductLocationOffering;
+use App\Models\ProviderLocationOffering;
+use App\Models\ProviderLocationTarget;
+use App\Models\Service;
+use Illuminate\Database\Eloquent\Collection;
+
+class LocationAvailabilityService
+{
+    public static function forProvider(int $providerId, ?string $serviceType = null, bool $enabledOnly = true): Collection
+    {
+        return ProviderLocationOffering::query()
+            ->with(['locationOption.primaryGroup', 'targets'])
+            ->where('provider_id', $providerId)
+            ->when($serviceType, fn ($query) => $query->where('service_type', $serviceType))
+            ->when($enabledOnly, fn ($query) => $query->where('enabled', true))
+            ->whereHas('locationOption', fn ($query) => $query->where('status', LocationOption::STATUS_ACTIVE))
+            ->orderBy('service_type')
+            ->get()
+            ->sortBy([
+                fn (ProviderLocationOffering $offering) => $offering->locationOption->primaryGroup?->sort_order ?? PHP_INT_MAX,
+                fn (ProviderLocationOffering $offering) => $offering->locationOption->sort_order,
+                fn (ProviderLocationOffering $offering) => $offering->locationOption->display_name,
+            ])
+            ->values();
+    }
+
+    public static function forProduct(int|Product $product, ?string $serviceType = null, bool $enabledOnly = true): Collection
+    {
+        $productId = $product instanceof Product ? $product->id : $product;
+
+        return ProductLocationOffering::query()
+            ->with(['providerLocationOffering.locationOption.primaryGroup', 'providerLocationOffering.targets'])
+            ->where('product_id', $productId)
+            ->when($enabledOnly, fn ($query) => $query->where('enabled', true))
+            ->whereHas('providerLocationOffering', function ($query) use ($serviceType, $enabledOnly) {
+                $query
+                    ->when($serviceType, fn ($query) => $query->where('service_type', $serviceType))
+                    ->when($enabledOnly, fn ($query) => $query->where('enabled', true))
+                    ->whereHas('locationOption', fn ($query) => $query->where('status', LocationOption::STATUS_ACTIVE));
+            })
+            ->orderBy('sort_order')
+            ->get()
+            ->sortBy([
+                fn (ProductLocationOffering $offering) => $offering->providerLocationOffering->locationOption->primaryGroup?->sort_order ?? PHP_INT_MAX,
+                fn (ProductLocationOffering $offering) => $offering->sort_order,
+                fn (ProductLocationOffering $offering) => $offering->providerLocationOffering->locationOption->display_name,
+            ])
+            ->values();
+    }
+
+    public static function resolveTarget(int|ProviderLocationOffering $providerLocationOffering): ?ProviderLocationTarget
+    {
+        $providerLocationOfferingId = $providerLocationOffering instanceof ProviderLocationOffering
+            ? $providerLocationOffering->id
+            : $providerLocationOffering;
+
+        return ProviderLocationTarget::query()
+            ->where('provider_location_offering_id', $providerLocationOfferingId)
+            ->where('status', ProviderLocationTarget::STATUS_ACTIVE)
+            ->orderByDesc('priority')
+            ->orderByDesc('weight')
+            ->orderBy('id')
+            ->first();
+    }
+
+    public static function snapshotSelection(Service $service, int|ProviderLocationOffering $providerLocationOffering): array
+    {
+        $offering = $providerLocationOffering instanceof ProviderLocationOffering
+            ? $providerLocationOffering->loadMissing('locationOption', 'targets')
+            : ProviderLocationOffering::with(['locationOption', 'targets'])->findOrFail($providerLocationOffering);
+
+        $target = self::resolveTarget($offering);
+
+        $snapshot = [
+            'location_option_id' => (string) $offering->location_option_id,
+            'provider_location_offering_id' => (string) $offering->id,
+            'external_location_code' => (string) ($target?->external_location_code ?? $target?->external_location_id ?? ''),
+            'display_name' => $offering->locationOption->display_name,
+        ];
+
+        foreach ($snapshot as $key => $value) {
+            $service->properties()->updateOrCreate([
+                'key' => $key,
+            ], [
+                'name' => str_replace('_', ' ', $key),
+                'value' => $value,
+            ]);
+        }
+
+        return $snapshot;
+    }
+
+    public static function checkoutOptionsForProduct(int|Product $product, ?string $serviceType = null): array
+    {
+        return self::forProduct($product, $serviceType)
+            ->mapWithKeys(function (ProductLocationOffering $productOffering) {
+                $providerOffering = $productOffering->providerLocationOffering;
+                $location = $providerOffering->locationOption;
+                $group = $location->primaryGroup?->name ?? 'Other';
+
+                return [
+                    $productOffering->id => [
+                        'label' => $location->display_name,
+                        'group' => $group,
+                        'provider_location_offering_id' => $providerOffering->id,
+                        'price_delta' => $productOffering->price_delta,
+                    ],
+                ];
+            })
+            ->all();
+    }
+}

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -119,6 +119,20 @@ return [
                 'delete' => 'Delete Config Options',
                 'deleteAny' => 'Bulk Delete Config Options',
             ],
+            'location_groups' => [
+                'create' => 'Create Location Groups',
+                'update' => 'Update Location Groups',
+                'viewAny' => 'View Location Groups',
+                'delete' => 'Delete Location Groups',
+                'deleteAny' => 'Bulk Delete Location Groups',
+            ],
+            'location_options' => [
+                'create' => 'Create Location Options',
+                'update' => 'Update Location Options',
+                'viewAny' => 'View Location Options',
+                'delete' => 'Delete Location Options',
+                'deleteAny' => 'Bulk Delete Location Options',
+            ],
             'tax_rates' => [
                 'create' => 'Create Tax Rates',
                 'update' => 'Update Tax Rates',

--- a/database/migrations/2026_07_01_000001_create_location_catalog_tables.php
+++ b/database/migrations/2026_07_01_000001_create_location_catalog_tables.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Models\Extension;
+use App\Models\Product;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('location_groups', function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->unique();
+            $table->string('name');
+            $table->string('group_type')->default('custom');
+            $table->json('service_types')->nullable();
+            $table->string('status')->default('active');
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::table('location_groups', function (Blueprint $table) {
+            $table->foreignId('parent_id')
+                ->nullable()
+                ->after('id')
+                ->constrained('location_groups')
+                ->nullOnDelete();
+        });
+
+        Schema::create('location_options', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('primary_group_id')->nullable()->constrained('location_groups')->nullOnDelete();
+            $table->unsignedInteger('legacy_id')->nullable()->index();
+            $table->string('code')->unique();
+            $table->string('display_name');
+            $table->string('option_type')->default('geo');
+            $table->string('place_country_iso2', 2)->nullable()->index();
+            $table->string('place_subdivision_code')->nullable()->index();
+            $table->string('network_type')->nullable();
+            $table->string('isp_name')->nullable();
+            $table->string('selection_policy')->default('fixed');
+            $table->json('service_types')->nullable();
+            $table->string('status')->default('active');
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('provider_location_offerings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Extension::class, 'provider_id')->constrained('extensions')->cascadeOnDelete();
+            $table->foreignId('location_option_id')->constrained('location_options')->cascadeOnDelete();
+            $table->string('service_type');
+            $table->boolean('enabled')->default(true);
+            $table->string('stock_state')->default('unknown');
+            $table->json('capabilities')->nullable();
+            $table->timestamp('last_synced_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['provider_id', 'location_option_id', 'service_type'], 'provider_location_offerings_unique');
+        });
+
+        Schema::create('provider_location_targets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('provider_location_offering_id')->constrained('provider_location_offerings')->cascadeOnDelete();
+            $table->string('external_location_id')->nullable()->index();
+            $table->string('external_location_code')->nullable()->index();
+            $table->string('external_name')->nullable();
+            $table->integer('priority')->default(0);
+            $table->integer('weight')->default(100);
+            $table->json('raw_payload')->nullable();
+            $table->string('status')->default('active');
+            $table->timestamps();
+        });
+
+        Schema::create('product_location_offerings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Product::class)->constrained()->cascadeOnDelete();
+            $table->foreignId('provider_location_offering_id')->constrained('provider_location_offerings')->cascadeOnDelete();
+            $table->boolean('enabled')->default(true);
+            $table->decimal('price_delta', 17, 2)->nullable();
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->unique(['product_id', 'provider_location_offering_id'], 'product_location_offerings_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('product_location_offerings');
+        Schema::dropIfExists('provider_location_targets');
+        Schema::dropIfExists('provider_location_offerings');
+        Schema::dropIfExists('location_options');
+        Schema::dropIfExists('location_groups');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
         Role::updateOrCreate(['name' => 'admin'], ['permissions' => ['*']]);
+        $this->call(LocationCatalogSeeder::class);
 
         foreach (Settings::settings() as $settings) {
             foreach ($settings as $setting) {

--- a/database/seeders/LocationCatalogSeeder.php
+++ b/database/seeders/LocationCatalogSeeder.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\LocationGroup;
+use App\Models\LocationOption;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class LocationCatalogSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $groups = [
+            'us' => LocationGroup::updateOrCreate(
+                ['code' => 'us'],
+                ['name' => 'US', 'group_type' => LocationGroup::TYPE_COUNTRY_BUNDLE, 'service_types' => ['vps', 'proxy', 'vpn'], 'status' => LocationGroup::STATUS_ACTIVE, 'sort_order' => 10]
+            ),
+            'eu' => LocationGroup::updateOrCreate(
+                ['code' => 'eu'],
+                ['name' => 'EU', 'group_type' => LocationGroup::TYPE_REGION, 'service_types' => ['vps', 'proxy', 'vpn'], 'status' => LocationGroup::STATUS_ACTIVE, 'sort_order' => 20]
+            ),
+            'vn' => LocationGroup::updateOrCreate(
+                ['code' => 'vn'],
+                ['name' => 'VN', 'group_type' => LocationGroup::TYPE_ISP_BUNDLE, 'service_types' => ['proxy', 'vpn'], 'status' => LocationGroup::STATUS_ACTIVE, 'sort_order' => 30]
+            ),
+            'other' => LocationGroup::updateOrCreate(
+                ['code' => 'other'],
+                ['name' => 'Other', 'group_type' => LocationGroup::TYPE_CUSTOM, 'service_types' => ['vps', 'proxy', 'vpn'], 'status' => LocationGroup::STATUS_ACTIVE, 'sort_order' => 100]
+            ),
+        ];
+
+        foreach ($this->locations($groups) as $location) {
+            LocationOption::updateOrCreate(
+                ['code' => $location['code']],
+                array_merge([
+                    'selection_policy' => LocationOption::POLICY_FIXED,
+                    'status' => LocationOption::STATUS_ACTIVE,
+                    'service_types' => ['vps', 'proxy', 'vpn'],
+                    'metadata' => ['source' => 'initial_location_sheet'],
+                ], $location)
+            );
+        }
+    }
+
+    private function locations(array $groups): array
+    {
+        $usStates = [
+            [1, 'Nevada', 'NV'],
+            [2, 'California', 'CA'],
+            [3, 'Texas', 'TX'],
+            [4, 'New Jersey', 'NJ'],
+            [5, 'Virginia', 'VA'],
+            [6, 'New York', 'NY'],
+            [7, 'Colorado', 'CO'],
+            [8, 'Florida', 'FL'],
+            [9, 'Massachusetts', 'MA'],
+            [10, 'Illinois', 'IL'],
+            [11, 'Washington', 'WA'],
+            [14, 'Oregon', 'OR'],
+            [15, 'Missouri', 'MO'],
+            [19, 'Michigan', 'MI'],
+            [20, 'Utah', 'UT'],
+            [21, 'North Carolina', 'NC'],
+            [29, 'Arizona', 'AZ'],
+            [38, 'Wisconsin', 'WI'],
+            [39, 'Indiana', 'IN'],
+            [45, 'Ohio', 'OH'],
+            [49, 'New Mexico', 'NM'],
+            [133, 'Pennsylvania', 'PA'],
+            [134, 'Delaware', 'DE'],
+            [135, 'Arkansas', 'AR'],
+        ];
+
+        $locations = [
+            $this->location($groups['us'], 0, 'Random US', LocationOption::TYPE_SYNTHETIC_POOL, ['place_country_iso2' => 'US', 'selection_policy' => LocationOption::POLICY_RANDOM]),
+            $this->location($groups['other'], 12, 'United Kingdom', LocationOption::TYPE_GEO, ['place_country_iso2' => 'GB']),
+            $this->location($groups['other'], 13, 'Unknown', LocationOption::TYPE_UNKNOWN, ['status' => LocationOption::STATUS_HIDDEN]),
+            $this->location($groups['eu'], 16, 'Netherlands', LocationOption::TYPE_GEO, ['place_country_iso2' => 'NL']),
+            $this->location($groups['other'], 17, 'Georgia', LocationOption::TYPE_GEO, ['metadata' => ['source' => 'initial_location_sheet', 'needs_review' => true]]),
+            $this->location($groups['other'], 23, 'Singapore', LocationOption::TYPE_GEO, ['place_country_iso2' => 'SG']),
+            $this->location($groups['other'], 24, 'Canada', LocationOption::TYPE_GEO, ['place_country_iso2' => 'CA']),
+            $this->location($groups['eu'], 25, 'France', LocationOption::TYPE_GEO, ['place_country_iso2' => 'FR']),
+            $this->location($groups['other'], 26, 'Australia', LocationOption::TYPE_GEO, ['place_country_iso2' => 'AU']),
+            $this->location($groups['eu'], 27, 'Poland', LocationOption::TYPE_GEO, ['place_country_iso2' => 'PL']),
+            $this->location($groups['eu'], 28, 'Germany', LocationOption::TYPE_GEO, ['place_country_iso2' => 'DE']),
+            $this->location($groups['eu'], 30, 'Italy', LocationOption::TYPE_GEO, ['place_country_iso2' => 'IT']),
+            $this->location($groups['eu'], 31, 'Belgium', LocationOption::TYPE_GEO, ['place_country_iso2' => 'BE']),
+            $this->location($groups['eu'], 32, 'Czech Republic', LocationOption::TYPE_GEO, ['place_country_iso2' => 'CZ']),
+            $this->location($groups['eu'], 33, 'Finland', LocationOption::TYPE_GEO, ['place_country_iso2' => 'FI']),
+            $this->location($groups['eu'], 34, 'Ireland', LocationOption::TYPE_GEO, ['place_country_iso2' => 'IE']),
+            $this->location($groups['eu'], 35, 'Lithuania', LocationOption::TYPE_GEO, ['place_country_iso2' => 'LT']),
+            $this->location($groups['eu'], 36, 'Portugal', LocationOption::TYPE_GEO, ['place_country_iso2' => 'PT']),
+            $this->location($groups['eu'], 37, 'Spain', LocationOption::TYPE_GEO, ['place_country_iso2' => 'ES']),
+            $this->location($groups['eu'], 40, 'EU', LocationOption::TYPE_REGION, ['selection_policy' => LocationOption::POLICY_PROVIDER_DECIDES]),
+            $this->location($groups['other'], 41, 'Hong Kong', LocationOption::TYPE_GEO, ['place_country_iso2' => 'HK']),
+            $this->location($groups['us'], 43, 'US', LocationOption::TYPE_GEO, ['place_country_iso2' => 'US', 'status' => LocationOption::STATUS_DEPRECATED, 'metadata' => ['source' => 'initial_location_sheet', 'alias_of' => 'united-states']]),
+            $this->location($groups['other'], 44, 'Canada-Promo', LocationOption::TYPE_PROMO_POOL, ['place_country_iso2' => 'CA']),
+            $this->location($groups['other'], 50, 'Mexico', LocationOption::TYPE_GEO, ['place_country_iso2' => 'MX']),
+            $this->location($groups['other'], 51, 'Ukraine', LocationOption::TYPE_GEO, ['place_country_iso2' => 'UA']),
+            $this->location($groups['other'], 54, 'Argentina', LocationOption::TYPE_GEO, ['place_country_iso2' => 'AR']),
+            $this->location($groups['other'], 56, 'Philippines', LocationOption::TYPE_GEO, ['place_country_iso2' => 'PH']),
+            $this->location($groups['eu'], 57, 'Latvia', LocationOption::TYPE_GEO, ['place_country_iso2' => 'LV']),
+            $this->location($groups['other'], 58, 'Russia', LocationOption::TYPE_GEO, ['place_country_iso2' => 'RU']),
+            $this->location($groups['other'], 69, 'Turkey', LocationOption::TYPE_GEO, ['place_country_iso2' => 'TR']),
+            $this->location($groups['eu'], 70, 'Romania', LocationOption::TYPE_GEO, ['place_country_iso2' => 'RO']),
+            $this->location($groups['other'], 72, 'Japan', LocationOption::TYPE_GEO, ['place_country_iso2' => 'JP']),
+            $this->location($groups['eu'], 73, 'Bulgaria', LocationOption::TYPE_GEO, ['place_country_iso2' => 'BG']),
+            $this->location($groups['other'], 75, 'Brazil', LocationOption::TYPE_GEO, ['place_country_iso2' => 'BR']),
+            $this->location($groups['other'], 76, 'India', LocationOption::TYPE_GEO, ['place_country_iso2' => 'IN']),
+            $this->location($groups['us'], 78, 'United States', LocationOption::TYPE_GEO, ['place_country_iso2' => 'US']),
+            $this->location($groups['other'], 80, 'Kazakhstan', LocationOption::TYPE_GEO, ['place_country_iso2' => 'KZ']),
+            $this->location($groups['other'], 87, 'Belarus', LocationOption::TYPE_GEO, ['place_country_iso2' => 'BY']),
+            $this->location($groups['other'], 93, 'China', LocationOption::TYPE_GEO, ['place_country_iso2' => 'CN']),
+            $this->location($groups['eu'], 98, 'Sweden', LocationOption::TYPE_GEO, ['place_country_iso2' => 'SE']),
+            $this->location($groups['other'], 99, 'South Korea', LocationOption::TYPE_GEO, ['place_country_iso2' => 'KR']),
+            $this->location($groups['other'], 102, 'Thailand', LocationOption::TYPE_GEO, ['place_country_iso2' => 'TH']),
+            $this->location($groups['other'], 104, 'Malaysia', LocationOption::TYPE_GEO, ['place_country_iso2' => 'MY']),
+            $this->location($groups['other'], 106, 'Cambodia', LocationOption::TYPE_GEO, ['place_country_iso2' => 'KH']),
+            $this->location($groups['other'], 108, 'Switzerland', LocationOption::TYPE_GEO, ['place_country_iso2' => 'CH']),
+            $this->location($groups['other'], 109, 'Norway', LocationOption::TYPE_GEO, ['place_country_iso2' => 'NO']),
+            $this->location($groups['other'], 110, 'South Africa', LocationOption::TYPE_GEO, ['place_country_iso2' => 'ZA']),
+            $this->location($groups['other'], 111, 'Nigeria', LocationOption::TYPE_GEO, ['place_country_iso2' => 'NG']),
+            $this->location($groups['other'], 112, 'Taiwan', LocationOption::TYPE_GEO, ['place_country_iso2' => 'TW']),
+            $this->location($groups['other'], 115, 'Armenia', LocationOption::TYPE_GEO, ['place_country_iso2' => 'AM']),
+            $this->location($groups['other'], 116, 'Bangladesh', LocationOption::TYPE_GEO, ['place_country_iso2' => 'BD']),
+            $this->location($groups['other'], 117, 'Indonesia', LocationOption::TYPE_GEO, ['place_country_iso2' => 'ID']),
+            $this->location($groups['eu'], 118, 'Cyprus', LocationOption::TYPE_GEO, ['place_country_iso2' => 'CY']),
+            $this->location($groups['eu'], 120, 'Hungary', LocationOption::TYPE_GEO, ['place_country_iso2' => 'HU']),
+            $this->location($groups['other'], 121, 'Israel', LocationOption::TYPE_GEO, ['place_country_iso2' => 'IL']),
+            $this->location($groups['eu'], 122, 'Denmark', LocationOption::TYPE_GEO, ['place_country_iso2' => 'DK']),
+            $this->location($groups['eu'], 124, 'Greece', LocationOption::TYPE_GEO, ['place_country_iso2' => 'GR']),
+            $this->location($groups['eu'], 125, 'Malta', LocationOption::TYPE_GEO, ['place_country_iso2' => 'MT']),
+            $this->location($groups['other'], 126, 'United Arab Emirates', LocationOption::TYPE_GEO, ['place_country_iso2' => 'AE']),
+            $this->location($groups['vn'], 18, 'Viet Nam - Viettel', LocationOption::TYPE_ISP_POOL, ['place_country_iso2' => 'VN', 'isp_name' => 'Viettel', 'service_types' => ['proxy', 'vpn']]),
+            $this->location($groups['vn'], 22, 'Viet Nam - Residential', LocationOption::TYPE_NETWORK_POOL, ['place_country_iso2' => 'VN', 'network_type' => LocationOption::NETWORK_RESIDENTIAL, 'service_types' => ['proxy', 'vpn']]),
+            $this->location($groups['vn'], 42, 'Viet Nam - Ha Noi', LocationOption::TYPE_GEO, ['place_country_iso2' => 'VN']),
+            $this->location($groups['vn'], 46, 'Viet Nam - FPT', LocationOption::TYPE_ISP_POOL, ['place_country_iso2' => 'VN', 'isp_name' => 'FPT', 'service_types' => ['proxy', 'vpn']]),
+            $this->location($groups['vn'], 53, 'Viet Nam - CMC', LocationOption::TYPE_ISP_POOL, ['place_country_iso2' => 'VN', 'isp_name' => 'CMC', 'service_types' => ['proxy', 'vpn']]),
+            $this->location($groups['vn'], 55, 'Viet Nam - VPN', LocationOption::TYPE_NETWORK_POOL, ['place_country_iso2' => 'VN', 'network_type' => LocationOption::NETWORK_VPN, 'service_types' => ['vpn']]),
+            $this->location($groups['vn'], 129, 'Viet Nam - VNPT', LocationOption::TYPE_ISP_POOL, ['place_country_iso2' => 'VN', 'isp_name' => 'VNPT', 'service_types' => ['proxy', 'vpn']]),
+            $this->location($groups['vn'], 132, 'Residential - VT', LocationOption::TYPE_ISP_POOL, ['place_country_iso2' => 'VN', 'network_type' => LocationOption::NETWORK_RESIDENTIAL, 'isp_name' => 'Viettel', 'service_types' => ['proxy']]),
+        ];
+
+        foreach ($usStates as [$legacyId, $name, $subdivision]) {
+            $locations[] = $this->location($groups['us'], $legacyId, $name, LocationOption::TYPE_GEO, [
+                'place_country_iso2' => 'US',
+                'place_subdivision_code' => $subdivision,
+            ]);
+        }
+
+        return $locations;
+    }
+
+    private function location(LocationGroup $group, int $legacyId, string $name, string $type, array $overrides = []): array
+    {
+        return array_merge([
+            'primary_group_id' => $group->id,
+            'legacy_id' => $legacyId,
+            'code' => Str::slug($name),
+            'display_name' => $name,
+            'option_type' => $type,
+        ], $overrides);
+    }
+}

--- a/tests/Feature/LocationCatalogTest.php
+++ b/tests/Feature/LocationCatalogTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\LocationGroup;
+use App\Models\LocationOption;
+use App\Models\ProductLocationOffering;
+use App\Models\ProviderLocationOffering;
+use App\Models\ProviderLocationTarget;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\User;
+use App\Services\LocationAvailabilityService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LocationCatalogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_initial_catalog_seed_creates_groups_and_preserves_legacy_ids(): void
+    {
+        $this->assertDatabaseHas('location_groups', [
+            'code' => 'us',
+            'name' => 'US',
+        ]);
+
+        $this->assertDatabaseHas('location_groups', [
+            'code' => 'eu',
+            'name' => 'EU',
+        ]);
+
+        $this->assertDatabaseHas('location_options', [
+            'legacy_id' => 13,
+            'code' => 'unknown',
+            'status' => LocationOption::STATUS_HIDDEN,
+        ]);
+
+        $this->assertDatabaseHas('location_options', [
+            'legacy_id' => 43,
+            'code' => 'us',
+            'status' => LocationOption::STATUS_DEPRECATED,
+        ]);
+
+        $this->assertDatabaseHas('location_options', [
+            'legacy_id' => 78,
+            'code' => 'united-states',
+            'status' => LocationOption::STATUS_ACTIVE,
+        ]);
+    }
+
+    public function test_provider_and_product_availability_resolve_provider_target(): void
+    {
+        [$provider, $offering, $productOffering] = $this->createLocationOffering();
+
+        $providerLocations = LocationAvailabilityService::forProvider($provider->id, ProviderLocationOffering::SERVICE_VPS);
+        $productLocations = LocationAvailabilityService::forProduct($productOffering->product_id, ProviderLocationOffering::SERVICE_VPS);
+        $target = LocationAvailabilityService::resolveTarget($offering->id);
+
+        $this->assertCount(1, $providerLocations);
+        $this->assertSame($offering->id, $providerLocations->first()->id);
+        $this->assertCount(1, $productLocations);
+        $this->assertSame($productOffering->id, $productLocations->first()->id);
+        $this->assertSame('us-east-1', $target->external_location_code);
+    }
+
+    public function test_disabled_and_hidden_locations_are_not_returned_for_checkout(): void
+    {
+        [, $offering, $productOffering] = $this->createLocationOffering();
+
+        $offering->update(['enabled' => false]);
+        $this->assertCount(0, LocationAvailabilityService::forProduct($productOffering->product_id));
+
+        $offering->update(['enabled' => true]);
+        $offering->locationOption->update(['status' => LocationOption::STATUS_HIDDEN]);
+        $this->assertCount(0, LocationAvailabilityService::forProduct($productOffering->product_id));
+    }
+
+    public function test_snapshot_selection_stores_service_properties_independent_of_future_label_changes(): void
+    {
+        [, $offering, $productOffering] = $this->createLocationOffering();
+        $product = $productOffering->product;
+        $plan = $product->plans()->first();
+        $service = Service::factory()->create([
+            'product_id' => $product->id,
+            'plan_id' => $plan->id,
+            'user_id' => User::factory(),
+            'status' => Service::STATUS_PENDING,
+        ]);
+
+        $snapshot = LocationAvailabilityService::snapshotSelection($service, $offering);
+        $offering->locationOption->update(['display_name' => 'Renamed United States']);
+
+        $this->assertSame('United States', $snapshot['display_name']);
+        $this->assertDatabaseHas('properties', [
+            'model_id' => $service->id,
+            'model_type' => $service->getMorphClass(),
+            'key' => 'display_name',
+            'value' => 'United States',
+        ]);
+        $this->assertDatabaseHas('properties', [
+            'model_id' => $service->id,
+            'model_type' => $service->getMorphClass(),
+            'key' => 'external_location_code',
+            'value' => 'us-east-1',
+        ]);
+    }
+
+    public function test_deleting_group_keeps_location_option_and_moves_it_to_no_group(): void
+    {
+        $group = LocationGroup::create([
+            'code' => 'temp',
+            'name' => 'Temp',
+        ]);
+        $option = LocationOption::create([
+            'primary_group_id' => $group->id,
+            'code' => 'temp-location',
+            'display_name' => 'Temp Location',
+            'option_type' => LocationOption::TYPE_GEO,
+        ]);
+
+        $group->delete();
+
+        $this->assertDatabaseHas('location_options', [
+            'id' => $option->id,
+            'primary_group_id' => null,
+        ]);
+    }
+
+    private function createLocationOffering(): array
+    {
+        $provider = Server::create([
+            'name' => 'Test Provider',
+            'extension' => 'TestProvider',
+            'type' => 'server',
+            'enabled' => true,
+        ]);
+
+        $location = LocationOption::where('code', 'united-states')->firstOrFail();
+
+        $offering = ProviderLocationOffering::create([
+            'provider_id' => $provider->id,
+            'location_option_id' => $location->id,
+            'service_type' => ProviderLocationOffering::SERVICE_VPS,
+            'enabled' => true,
+            'stock_state' => ProviderLocationOffering::STOCK_AVAILABLE,
+        ]);
+
+        ProviderLocationTarget::create([
+            'provider_location_offering_id' => $offering->id,
+            'external_location_code' => 'us-east-1',
+            'external_name' => 'US East',
+            'priority' => 10,
+            'weight' => 100,
+        ]);
+
+        $productData = $this->createProduct([
+            'server_id' => $provider->id,
+        ]);
+
+        $productOffering = ProductLocationOffering::create([
+            'product_id' => $productData->product->id,
+            'provider_location_offering_id' => $offering->id,
+            'enabled' => true,
+        ]);
+
+        return [$provider, $offering, $productOffering];
+    }
+}


### PR DESCRIPTION
## Summary\n- add core location groups and location options catalog\n- add provider/product location offering mappings for server extensions\n- add LocationAvailabilityService for provider extension consumption and service snapshots\n- seed initial US/EU/VN/Other catalog from the provided location list\n\n## Tests\n- php -l on feature files\n- ./vendor/bin/pint --test on feature files\n- APP_ENV=testing DB_CONNECTION=sqlite php artisan test tests/Feature/LocationCatalogTest.php\n- APP_ENV=testing DB_CONNECTION=sqlite php artisan test