### PR TITLE
feat: Implement Config Option Cloning and Product-Specific Option Assignment

### DIFF
--- a/app/Admin/Resources/ConfigOptionResource.php
+++ b/app/Admin/Resources/ConfigOptionResource.php
@@ -76,6 +76,7 @@ class ConfigOptionResource extends Resource
                                 ->relationship('products', 'name')
                                 ->multiple()
                                 ->preload()
+                                ->live()
                                 ->placeholder('Select the products that this configuration option belongs to'),
                         ]),
                         Tab::make('Options')
@@ -114,6 +115,16 @@ class ConfigOptionResource extends Resource
                                             ->required()
                                             ->maxLength(255)
                                             ->placeholder('Enter the environment variable name'),
+                                        Select::make('products')
+                                            ->label('Products')
+                                            ->relationship('products', 'name', fn (Builder $query, Get $get) => $query->whereIn('products.id', $get('../../products') ?? []))
+                                            ->multiple()
+                                            ->preload()
+                                            ->placeholder('Select the products that this option belongs to')
+                                            ->default(function (Get $get) {
+                                                return $get('../../products') ?? [];
+                                            })
+                                            ->columnSpanFull(),
                                         // if the type is select, radio or checkbox then allow unlimited children (otherwise only allow 1)
                                         ProductResource::plan()->columnSpanFull()->label('Pricing')->reorderable(false)->deleteAction(null),
                                     ]),
@@ -148,7 +159,52 @@ class ConfigOptionResource extends Resource
                 //
             ])
             ->recordActions([
-                EditAction::make(),
+                \Filament\Actions\EditAction::make(),
+                \Filament\Actions\Action::make('clone')
+                    ->label('Clone')
+                    ->icon('heroicon-o-document-duplicate')
+                    ->color('info')
+                    ->action(function (ConfigOption $record) {
+                        \Illuminate\Support\Facades\DB::transaction(function () use ($record) {
+                            // 1. Replicate parent
+                            $clone = $record->replicate();
+                            $clone->name = $clone->name . ' (Clone)';
+                            $clone->save();
+
+                            // 2. Replicate children
+                            foreach ($record->children as $child) {
+                                $childClone = $child->replicate();
+                                $childClone->parent_id = $clone->id;
+                                $childClone->save();
+
+                                // 3. Replicate plans under the child
+                                foreach ($child->plans as $plan) {
+                                    $planClone = $plan->replicate();
+                                    $planClone->priceable_id = $childClone->id;
+                                    $planClone->priceable_type = get_class($childClone);
+                                    $planClone->save();
+
+                                    // 4. Replicate prices under the plan
+                                    foreach ($plan->prices as $price) {
+                                        $priceClone = $price->replicate();
+                                        $priceClone->plan_id = $planClone->id;
+                                        $priceClone->save();
+                                    }
+                                }
+
+                                // 5. Replicate product mapping for child options
+                                $childClone->products()->sync($child->products->pluck('id'));
+                            }
+
+                            // 6. Replicate product mapping for parent option
+                            $clone->products()->sync($record->products->pluck('id'));
+                        });
+
+                        \Filament\Notifications\Notification::make()
+                            ->title('Config Option Cloned Successfully')
+                            ->success()
+                            ->send();
+                    })
             ])
             ->defaultSort(function (Builder $query): Builder {
                 return $query

--- a/app/Livewire/Products/Checkout.php
+++ b/app/Livewire/Products/Checkout.php
@@ -15,6 +15,25 @@ use Livewire\Attributes\Url;
 
 class Checkout extends Component
 {
+    public function boot()
+    {
+        \App\Models\ConfigOption::setProductContext($this->product);
+        $this->filterConfigOptions();
+    }
+
+    protected function filterConfigOptions()
+    {
+        if ($this->product instanceof \App\Models\Product && $this->product->relationLoaded('configOptions')) {
+            $filtered = $this->product->configOptions->filter(function ($option) {
+                if (in_array($option->type, ['select', 'radio', 'slider', 'checkbox'])) {
+                    return $option->children->isNotEmpty();
+                }
+                return true;
+            });
+            $this->product->setRelation('configOptions', $filtered);
+        }
+    }
+
     public $product;
 
     public Category $category;
@@ -42,6 +61,9 @@ class Checkout extends Component
     public function mount($product)
     {
         $this->product = $this->category->products()->where('slug', $product)->firstOrFail();
+        \App\Models\ConfigOption::setProductContext($this->product);
+        $this->product->load(['configOptions.children']);
+        $this->filterConfigOptions();
         if ($this->product->stock === 0 || !$this->product->price()->available) {
             return $this->redirect(route('products.show', ['category' => $this->category, 'product' => $this->product]), true);
         }
@@ -72,7 +94,7 @@ class Checkout extends Component
                     return [$option->id => isset($this->configOptions[$option->id]) && in_array($this->configOptions[$option->id], [true, 'true'], true) ? true : false];
                 }
 
-                return [$option->id => $this->configOptions[$option->id] ?? $option->children->first()->id];
+                return [$option->id => $this->configOptions[$option->id] ?? $option->children->first()?->id];
             })->toArray();
             foreach ($this->getCheckoutConfig() as $config) {
                 if (in_array($config['type'], ['select', 'radio'])) {
@@ -243,7 +265,7 @@ class Checkout extends Component
                     'option_name' => $option->name,
                     'option_type' => $option->type,
                     'option_env_variable' => $option->env_variable,
-                    'value' => isset($this->configOptions[$option->id]) && in_array($this->configOptions[$option->id], [true, 'true'], true) ? $option->children->first()->id : null,
+                    'value' => isset($this->configOptions[$option->id]) && in_array($this->configOptions[$option->id], [true, 'true'], true) ? $option->children->first()?->id : null,
                     'value_name' => isset($this->configOptions[$option->id]) && in_array($this->configOptions[$option->id], [true, 'true'], true) ? 'Yes' : 'No',
                 ];
             }

--- a/app/Livewire/Products/Show.php
+++ b/app/Livewire/Products/Show.php
@@ -12,9 +12,31 @@ class Show extends Component
 
     public Category $category;
 
+    public function boot()
+    {
+        \App\Models\ConfigOption::setProductContext($this->product);
+        $this->filterConfigOptions();
+    }
+
+    protected function filterConfigOptions()
+    {
+        if ($this->product instanceof \App\Models\Product && $this->product->relationLoaded('configOptions')) {
+            $filtered = $this->product->configOptions->filter(function ($option) {
+                if (in_array($option->type, ['select', 'radio', 'slider', 'checkbox'])) {
+                    return $option->children->isNotEmpty();
+                }
+                return true;
+            });
+            $this->product->setRelation('configOptions', $filtered);
+        }
+    }
+
     public function mount($product)
     {
-        $this->product = $this->category->products()->where('slug', $product)->where('hidden', false)->with(['plans.prices', 'configOptions.children.plans.prices'])->firstOrFail();
+        $this->product = $this->category->products()->where('slug', $product)->where('hidden', false)->firstOrFail();
+        \App\Models\ConfigOption::setProductContext($this->product);
+        $this->product->load(['plans.prices', 'configOptions.children.plans.prices']);
+        $this->filterConfigOptions();
     }
 
     public function render()

--- a/app/Livewire/Services/Upgrade.php
+++ b/app/Livewire/Services/Upgrade.php
@@ -28,6 +28,25 @@ class Upgrade extends Component
 
     public $configOptions = [];
 
+    public function boot()
+    {
+        \App\Models\ConfigOption::setProductContext($this->upgradeProduct);
+        $this->filterConfigOptions();
+    }
+
+    protected function filterConfigOptions()
+    {
+        if ($this->upgradeProduct instanceof \App\Models\Product && $this->upgradeProduct->relationLoaded('upgradableConfigOptions')) {
+            $filtered = $this->upgradeProduct->upgradableConfigOptions->filter(function ($option) {
+                if (in_array($option->type, ['select', 'radio', 'slider', 'checkbox'])) {
+                    return $option->children->isNotEmpty();
+                }
+                return true;
+            });
+            $this->upgradeProduct->setRelation('upgradableConfigOptions', $filtered);
+        }
+    }
+
     public function mount()
     {
         $this->authorize('view', $this->service);
@@ -38,6 +57,9 @@ class Upgrade extends Component
             return $this->redirect(route('services.show', $this->service), true);
         }
         $this->upgradeProduct = $this->service->product;
+        \App\Models\ConfigOption::setProductContext($this->upgradeProduct);
+        $this->upgradeProduct->load(['upgradableConfigOptions.children']);
+        $this->filterConfigOptions();
         $this->upgrade = $this->service->product->id;
         $this->totalToday();
 
@@ -86,6 +108,9 @@ class Upgrade extends Component
             return;
         }
         $this->upgradeProduct = Product::findOrFail($upgrade);
+        \App\Models\ConfigOption::setProductContext($this->upgradeProduct);
+        $this->upgradeProduct->load(['upgradableConfigOptions.children']);
+        $this->filterConfigOptions();
     }
 
     public function nextStep()

--- a/app/Models/CartItem.php
+++ b/app/Models/CartItem.php
@@ -46,6 +46,7 @@ class CartItem extends Model
     {
         return Attribute::make(
             get: function () {
+                \App\Models\ConfigOption::setProductContext($this->product);
                 $total = 0;
                 $setup_fee = 0;
                 $total += $this->plan->price()->price;

--- a/app/Models/ConfigOption.php
+++ b/app/Models/ConfigOption.php
@@ -31,12 +31,46 @@ class ConfigOption extends Model implements Auditable
         return $this->belongsTo(ConfigOption::class, 'parent_id');
     }
 
+    public static ?\App\Models\Product $currentProductContext = null;
+
+    public static function setProductContext($product)
+    {
+        if ($product instanceof \App\Models\Product) {
+            self::$currentProductContext = $product;
+        } elseif (is_numeric($product)) {
+            self::$currentProductContext = \App\Models\Product::find($product);
+        } elseif (is_string($product)) {
+            self::$currentProductContext = \App\Models\Product::where('slug', $product)->first();
+        } else {
+            self::$currentProductContext = null;
+        }
+    }
+
     /**
      * Get the options that belong to the parent. (children or options)
      */
     public function children()
     {
-        return $this->hasMany(ConfigOption::class, 'parent_id')->orderBy('sort');
+        $query = $this->hasMany(ConfigOption::class, 'parent_id')->orderBy('sort');
+
+        if (self::$currentProductContext) {
+            $productId = self::$currentProductContext->id;
+
+            $query->where(function ($q) use ($productId) {
+                $q->whereNotExists(function ($sub) {
+                    $sub->select(\Illuminate\Support\Facades\DB::raw(1))
+                        ->from('config_option_products')
+                        ->whereColumn('config_option_products.config_option_id', 'config_options.id');
+                })->orWhereExists(function ($sub) use ($productId) {
+                    $sub->select(\Illuminate\Support\Facades\DB::raw(1))
+                        ->from('config_option_products')
+                        ->whereColumn('config_option_products.config_option_id', 'config_options.id')
+                        ->where('config_option_products.product_id', $productId);
+                });
+            });
+        }
+
+        return $query;
     }
 
     /**

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -36,7 +36,7 @@ class Product extends Model implements Auditable
      */
     public function configOptions(): HasManyThrough
     {
-        return $this->hasManyThrough(ConfigOption::class, ConfigOptionProduct::class, 'product_id', 'id', 'id', 'config_option_id')->where('config_options.hidden', false)->orderBy('config_options.sort', 'asc')->orderBy('config_options.id', 'desc');
+        return $this->hasManyThrough(ConfigOption::class, ConfigOptionProduct::class, 'product_id', 'id', 'id', 'config_option_id')->where('config_options.hidden', false)->whereNull('config_options.parent_id')->orderBy('config_options.sort', 'asc')->orderBy('config_options.id', 'desc');
     }
 
     /**
@@ -76,6 +76,6 @@ class Product extends Model implements Auditable
      */
     public function upgradableConfigOptions(): HasManyThrough
     {
-        return $this->hasManyThrough(ConfigOption::class, ConfigOptionProduct::class, 'product_id', 'id', 'id', 'config_option_id')->where('config_options.hidden', false)->where('config_options.upgradable', true)->orderBy('config_options.sort', 'asc')->orderBy('config_options.id', 'desc');
+        return $this->hasManyThrough(ConfigOption::class, ConfigOptionProduct::class, 'product_id', 'id', 'id', 'config_option_id')->where('config_options.hidden', false)->where('config_options.upgradable', true)->whereNull('config_options.parent_id')->orderBy('config_options.sort', 'asc')->orderBy('config_options.id', 'desc');
     }
 }


### PR DESCRIPTION
### Overview
This Pull Request introduces two major administrative and customer-experience features to Paymenter's Configurable Options system:
1. **Deep Cloning for Config Options**: Adds a row-level `Clone` action button on the Config Options list. This deeply replicates the parent Config Option, all its nested child options (values), their associated plans and pricing structures, and product mappings.
2. **Product-Specific Child Option Restrictions**: Allows administrators to restrict individual child options (values) to specific products instead of having all values apply universally. Child options can be linked only to a subset of the products the parent belongs to, preventing configuration mismatches.

---

### Technical Implementation

#### 1. Database Relationships & Query Filtering
* **`app/Models/ConfigOption.php`**: Declared a static `currentProductContext` property and modified the `children()` relationship query to apply dynamic SQL constraints when a product context is active. This filters out child option values that are not assigned to the active product.
* **`app/Models/Product.php`**: Appended a `whereNull('config_options.parent_id')` constraint to the `configOptions()` and `upgradableConfigOptions()` relationships. This prevents child options (which are now mapped to products in the pivot table) from being loaded as parent options, resolving checkout validation conflicts.
* **`app/Models/CartItem.php`**: Automatically binds the active product context in the `price()` attribute getter before evaluating pricing.

#### 2. Livewire Controllers & View Cleanup
* **`app/Livewire/Products/Checkout.php`**, **`app/Livewire/Products/Show.php`**, and **`app/Livewire/Services/Upgrade.php`**: Eager-loads the relationship collections and binds the active product context during `boot()` and `mount()`.
* **Dynamic Filtering**: Added a `filterConfigOptions()` helper to strip out parent options that contain **0 valid child values** under the current product context. This prevents empty dropdown/radio fields from rendering or causing checkout validation to fail.

#### 3. Filament Admin Interface
* **`app/Admin/Resources/ConfigOptionResource.php`**:
  * Added a row-level **Clone** action button inside `recordActions` that replicates parent/child options and relations in a secure database transaction.
  * Added a **Products** multiselect relation field inside the options Repeater. It queries only the products selected in the parent's **General** tab (utilizing a dynamic query modifier) and defaults to selecting all of them automatically.

---

### Verification and Testing
1. **Validation of Cloning**:
   * Navigate to **Admin -> Configuration -> Config Options**.
   * Click **Clone** on a row. Verify a duplicate named `[Original Name] (Clone)` is successfully created with all children and plans duplicated.
2. **Validation of Option Restrictions**:
   * Create a Config Option assigned to multiple products (e.g. `Product A` and `Product B`).
   * In the **Options** tab, edit a value (e.g. `32GB RAM`) to only have `Product B` assigned.
   * Go to checkout for `Product A` and verify that `32GB RAM` is hidden.
   * Go to checkout for `Product B` and verify that `32GB RAM` is visible and checks out successfully.
