### PR TITLE
Fix 500 when a plan has no price in the session/default currency

### DIFF
--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -54,6 +54,12 @@ class Plan extends Model implements Auditable
         $currency = $currency ?? session('currency', config('settings.default_currency'));
         $price = $this->prices->where('currency_code', $currency)->first();
 
+        // No price configured for this currency: return an unavailable price
+        // instead of dereferencing null (mirrors HasPlans::price()).
+        if (!$price) {
+            return new PriceClass(['price' => null, 'currency' => null]);
+        }
+
         return new PriceClass((object) [
             'price' => $price,
             'setup_fee' => $price->setup_fee,


### PR DESCRIPTION
## Problem

`Plan::price()` fetches the price row for the current currency and then reads `$price->setup_fee` and `$price->currency` **without checking that a row was found**:

```php
$currency = $currency ?? session('currency', config('settings.default_currency'));
$price = $this->prices->where('currency_code', $currency)->first();

return new PriceClass((object) [
    'price' => $price,
    'setup_fee' => $price->setup_fee,   // 💥 $price can be null
    'currency' => $price->currency,
]);
```

When a plan has **no price configured in the visitor's session currency** (or the default currency), `$price` is `null` and this throws:

```
Attempt to read property "setup_fee" on null
at app/Models/Plan.php:59
```

Because `CartItem::price` calls `$this->plan->price()`, and `Cart::mount()` → `updateTotal()` sums every item's price on page load, the **entire cart page returns a 500** as soon as an affected item is in the cart. The product/checkout pages are affected the same way anywhere the plan gets priced.

### Real-world trigger

A store offering multiple currencies where a product/plan was given a price in currency A but not currency B. A customer whose session currency is B adds it to the cart → hard 500 instead of a graceful "not available" state.

<details>
<summary>Stack trace (trimmed)</summary>

```
production.ERROR: Attempt to read property "setup_fee" on null
at app/Models/Plan.php:59
#2 app/Models/CartItem.php(51): App\Models\Plan->price()
...
#13 app/Livewire/Cart.php(48): Illuminate\Support\Collection->sum()
#14 app/Livewire/Cart.php(38): App\Livewire\Cart->updateTotal()
#15 App\Livewire\Cart->mount()
```
</details>

## Fix

Guard the null case and return an unavailable `Price` (null price/currency) instead of dereferencing null. This mirrors the existing pattern in `HasPlans::price()`, which already builds an unavailable price the same way. The `Price` class already renders this as **"Not available in your currency"** and exposes it via the `available` accessor, so downstream code and views handle it correctly.

```php
$price = $this->prices->where('currency_code', $currency)->first();

// No price configured for this currency: return an unavailable price
// instead of dereferencing null (mirrors HasPlans::price()).
if (!$price) {
    return new PriceClass(['price' => null, 'currency' => null]);
}
```

## Steps to reproduce

1. Enable at least two currencies.
2. Create a product with a plan priced in currency A only (no row for currency B).
3. As a visitor, switch the session currency to B.
4. Add the product to the cart and open the cart page → 500 (`Attempt to read property "setup_fee" on null`).

With this change the plan is treated as unavailable in currency B instead of crashing.

## Notes

- Affects `master` and the current release (v1.5.6); `app/Models/Plan.php` is unchanged between them.
- Minimal, behavior-preserving for the normal (price-exists) path.