### PR TITLE
fix: add applies_to to Coupon $fillable so coupon scope is saved

### DIFF
--- a/app/Models/Coupon.php
+++ b/app/Models/Coupon.php
@@ -11,6 +11,7 @@ class Coupon extends Model implements Auditable
 
     protected $fillable = [
         'type',
+        'applies_to',
         'time',
         'code',
         'value',


### PR DESCRIPTION
The `applies_to` column (added in migration
2025_09_20_185200_add_applies_to_to_coupons) is read by Coupon::calculateDiscount() and exposed via the "Applies To" select in the admin CouponResource, but it was missing from the model's $fillable.

Because CreateCoupon/EditCoupon persist through Eloquent mass-assignment (Coupon::create()/->update()), the admin's selection was silently dropped and every coupon fell back to the column default 'all'. As a result a coupon configured as "setup_fee" (or "price") only would also discount the other component e.g. a "20% off setup fee" coupon also took 20% off the recurring price and the value could never be changed from the form afterwards.

Adding 'applies_to' to $fillable lets the selection persist, it's a simple one-line change. 