### PR TITLE
fix: security improvements — SESSION_SECURE_COOKIE default, chmod 775, guarded fillable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY . ./
 RUN composer install --no-dev --optimize-autoloader
 
 RUN cp .env.example .env \
-    && chmod 777 -R bootstrap storage/* \
+    && chmod 775 -R bootstrap storage/* \
     && rm -rf .env bootstrap/cache/*.php \
     && chown -R nginx:nginx . \
     && rm /usr/local/etc/php-fpm.conf \

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -35,9 +35,6 @@ class User extends Authenticatable implements Auditable, FilamentUser, HasAvatar
         'last_name',
         'email',
         'password',
-        'role_id',
-        'tfa_secret',
-        'email_verified_at',
     ];
 
     /**

--- a/config/session.php
+++ b/config/session.php
@@ -164,7 +164,7 @@ return [
     |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE'),
+    'secure' => env('SESSION_SECURE_COOKIE', true),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Three security hardening changes:

1. **SESSION_SECURE_COOKIE defaults to `true`** — Without a default, session cookies can be transmitted over unencrypted HTTP if the deployer forgets to set `SESSION_SECURE_COOKIE=true` in `.env`.

2. **Dockerfile uses `chmod 775` instead of `777`** — Since `chown -R nginx:nginx .` follows immediately, world-writable permissions (777) are unnecessary. 775 is sufficient.

3. **Removed `tfa_secret`, `role_id`, `email_verified_at` from User `$fillable`** — These sensitive fields should not be mass-assignable even though no current non-admin code path exploits this. Defense-in-depth improvement.