### PR TITLE
Notification Template Translations & Preferred Language

### DIFF
--- a/app/Admin/Resources/NotificationTemplateResource.php
+++ b/app/Admin/Resources/NotificationTemplateResource.php
@@ -20,6 +20,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class NotificationTemplateResource extends Resource
 {
@@ -52,7 +53,7 @@ class NotificationTemplateResource extends Resource
                     ->collapsible()
                     ->schema([
                         TextInput::make('subject')
-                            ->required()
+                            ->required(fn ($livewire): bool => !($livewire instanceof EditNotificationTemplate) || $livewire->isEditingDefaultLocale())
                             ->maxLength(255),
                         Select::make('mail_enabled')
                             ->label('Mail Enabled')
@@ -66,7 +67,7 @@ class NotificationTemplateResource extends Resource
                         MarkdownEditor::make('body')
                             ->hint('Use either Markdown or HTML to compose the email body.')
                             ->disableAllToolbarButtons()
-                            ->required()
+                            ->required(fn ($livewire): bool => !($livewire instanceof EditNotificationTemplate) || $livewire->isEditingDefaultLocale())
                             ->columnSpanFull(),
                         TagsInput::make('cc')
                             ->placeholder('mail@example.com')
@@ -83,7 +84,7 @@ class NotificationTemplateResource extends Resource
                     ->schema([
                         TextInput::make('in_app_title')
                             ->label('In-App Title')
-                            ->required(fn (Get $get) => $get('in_app_enabled') !== NotificationEnabledStatus::Never->value)
+                            ->required(fn (Get $get, $livewire): bool => $get('in_app_enabled') !== NotificationEnabledStatus::Never->value && (!($livewire instanceof EditNotificationTemplate) || $livewire->isEditingDefaultLocale()))
                             ->disabled(fn (Get $get) => $get('in_app_enabled') === NotificationEnabledStatus::Never->value)
                             ->maxLength(255),
                         Select::make('in_app_enabled')
@@ -98,7 +99,7 @@ class NotificationTemplateResource extends Resource
                             ->required(),
                         TextInput::make('in_app_body')
                             ->label('In-App Body')
-                            ->required(fn (Get $get) => $get('in_app_enabled') !== NotificationEnabledStatus::Never->value)
+                            ->required(fn (Get $get, $livewire): bool => $get('in_app_enabled') !== NotificationEnabledStatus::Never->value && (!($livewire instanceof EditNotificationTemplate) || $livewire->isEditingDefaultLocale()))
                             ->disabled(fn (Get $get) => $get('in_app_enabled') === NotificationEnabledStatus::Never->value)
                             ->columnSpanFull(),
                         TextInput::make('in_app_url')
@@ -117,8 +118,42 @@ class NotificationTemplateResource extends Resource
     {
         return $table
             ->columns([
+                TextColumn::make('key')
+                    ->searchable()
+                    ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('subject')
                     ->searchable(),
+                TextColumn::make('available_locales')
+                    ->label('Languages')
+                    ->badge()
+                    ->getStateUsing(function (NotificationTemplate $record): array {
+                        $locales = array_map(
+                            static fn (string $locale): string => strtoupper($locale),
+                            $record->availableLocales()
+                        );
+
+                        if (count($locales) <= 5) {
+                            return $locales;
+                        }
+
+                        return [
+                            ...array_slice($locales, 0, 5),
+                            '[...]',
+                        ];
+                    })
+                    ->color('primary')
+                    ->tooltip(function (string $state, NotificationTemplate $record): ?string {
+                        if ($state !== '[...]') {
+                            return null;
+                        }
+
+                        $locales = array_map(
+                            static fn (string $locale): string => strtoupper($locale),
+                            $record->availableLocales()
+                        );
+
+                        return implode(', ', array_slice($locales, 5));
+                    }),
                 IconColumn::make('enabled')
                     ->boolean(),
             ])
@@ -130,11 +165,14 @@ class NotificationTemplateResource extends Resource
             ]);
     }
 
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->with('translations');
+    }
+
     public static function getRelations(): array
     {
-        return [
-            //
-        ];
+        return [];
     }
 
     public static function getPages(): array

--- a/app/Admin/Resources/NotificationTemplateResource/Pages/EditNotificationTemplate.php
+++ b/app/Admin/Resources/NotificationTemplateResource/Pages/EditNotificationTemplate.php
@@ -3,17 +3,142 @@
 namespace App\Admin\Resources\NotificationTemplateResource\Pages;
 
 use App\Admin\Resources\NotificationTemplateResource;
+use App\Classes\Settings;
+use App\Models\NotificationTemplate;
+use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
+use Filament\Actions\SelectAction;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
+/**
+ * @property-read NotificationTemplate $record
+ */
 class EditNotificationTemplate extends EditRecord
 {
     protected static string $resource = NotificationTemplateResource::class;
 
+    public ?string $activeLocale = null;
+
+    /**
+     * @var list<string>
+     */
+    protected array $nonTranslatableFields = [
+        'key',
+        'enabled',
+        'mail_enabled',
+        'in_app_enabled',
+        'cc',
+        'bcc',
+    ];
+
+    public function mount(int|string $record): void
+    {
+        $this->activeLocale = $this->getDefaultLocale();
+
+        parent::mount($record);
+    }
+
+    public function getDefaultLocale(): string
+    {
+        return (string) config('app.locale');
+    }
+
+    public function isEditingDefaultLocale(): bool
+    {
+        return $this->activeLocale === $this->getDefaultLocale();
+    }
+
+    public function updatedActiveLocale(?string $locale): void
+    {
+        if (!is_string($locale) || $locale === '') {
+            $this->activeLocale = $this->getDefaultLocale();
+        }
+
+        if (!in_array($this->activeLocale, array_keys(Settings::getAllowedLanguageOptions()), true)) {
+            $this->activeLocale = $this->getDefaultLocale();
+        }
+
+        $this->fillForm();
+    }
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        $localeAttributes = $this->record->attributesForLocale(
+            $this->activeLocale ?? $this->getDefaultLocale(),
+            $this->getDefaultLocale()
+        );
+
+        return array_merge($data, $localeAttributes);
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        /** @var NotificationTemplate $record */
+        $meta = collect($data)->only($this->nonTranslatableFields)->all();
+        $translatable = collect($data)->only(NotificationTemplate::translatableFields())->all();
+
+        $record->update($meta);
+
+        if ($this->isEditingDefaultLocale()) {
+            $record->update($translatable);
+
+            return $record->refresh();
+        }
+
+        $subject = trim((string) ($translatable['subject'] ?? ''));
+        $body = trim((string) ($translatable['body'] ?? ''));
+
+        if ($subject === '' && $body === '') {
+            $record->translations()->where('locale', $this->activeLocale)->delete();
+
+            return $record->refresh();
+        }
+
+        $record->translations()->updateOrCreate(
+            ['locale' => $this->activeLocale],
+            $translatable
+        );
+
+        return $record->refresh();
+    }
+
     protected function getHeaderActions(): array
     {
         return [
+            SelectAction::make('activeLocale')
+                ->options(fn (): array => Settings::getAllowedLanguageOptions()),
+            Action::make('prefillFromDefault')
+                ->label('Prefill from default language')
+                ->icon('ri-file-copy-line')
+                ->color('gray')
+                ->visible(fn (): bool => !$this->isEditingDefaultLocale())
+                ->requiresConfirmation()
+                ->modalHeading('Prefill from default language')
+                ->modalDescription('This copies the default language content into the form. Nothing is saved until you click Save.')
+                ->action(function (): void {
+                    $this->form->fill(array_merge(
+                        $this->record->attributesToArray(),
+                        $this->record->defaultLocaleAttributes(),
+                    ));
+
+                    Notification::make()
+                        ->title('Form prefilled from default language')
+                        ->success()
+                        ->send();
+                }),
             DeleteAction::make(),
         ];
+    }
+
+    protected function getSavedNotificationTitle(): ?string
+    {
+        $label = Settings::getAllowedLanguageOptions()[$this->activeLocale]
+            ?? Settings::getAvailableLanguageOptions()[$this->activeLocale]
+            ?? Str::upper((string) $this->activeLocale);
+
+        return "Saved ({$label})";
     }
 }

--- a/app/Admin/Resources/UserResource.php
+++ b/app/Admin/Resources/UserResource.php
@@ -11,6 +11,7 @@ use App\Admin\Resources\UserResource\Pages\ShowCredits;
 use App\Admin\Resources\UserResource\Pages\ShowInvoices;
 use App\Admin\Resources\UserResource\Pages\ShowServices;
 use App\Admin\Resources\UserResource\Pages\ShowTickets;
+use App\Classes\Settings;
 use App\Models\Credit;
 use App\Models\User;
 use Filament\Actions\EditAction;
@@ -55,6 +56,11 @@ class UserResource extends Resource
                 TextInput::make('first_name')->translateLabel()->required(),
                 TextInput::make('last_name')->translateLabel()->required(),
                 TextInput::make('email')->translateLabel()->email()->required()->unique('users', 'email', ignoreRecord: true),
+                Select::make('preferred_language')
+                    ->label('Preferred Language')
+                    ->options(fn (): array => Settings::getAllowedLanguageOptions())
+                    ->searchable()
+                    ->nullable(),
 
                 TextInput::make('password')->translateLabel()->password()->revealable()
                     ->dehydrateStateUsing(fn (string $state): string => Hash::make($state))

--- a/app/Classes/Settings.php
+++ b/app/Classes/Settings.php
@@ -655,13 +655,62 @@ class Settings
         return $settings;
     }
 
-    private static function getAvailableLanguages(): array
+    /**
+     * Languages shipped with Paymenter (folders under lang/), independent of allowed_languages.
+     *
+     * @return list<string>
+     */
+    public static function getAvailableLanguages(): array
     {
         return once(
             fn () => glob(base_path('lang/*'), GLOB_ONLYDIR)
             ? array_map('basename', glob(base_path('lang/*'), GLOB_ONLYDIR))
             : ['en']
         );
+    }
+
+    /**
+     * Locale options for admin UIs that may include languages outside allowed_languages.
+     *
+     * @return array<string, string>
+     */
+    public static function getAvailableLanguageOptions(): array
+    {
+        $locales = self::getAvailableLanguages();
+        $labels = config('app.available_locales', []);
+
+        $options = [];
+        foreach ($locales as $locale) {
+            $options[$locale] = $labels[$locale] ?? strtoupper($locale);
+        }
+
+        return $options;
+    }
+
+    /**
+     * Locale options limited to settings.allowed_languages (intersected with installed langs).
+     *
+     * @return array<string, string>
+     */
+    public static function getAllowedLanguageOptions(): array
+    {
+        $allowed = config('settings.allowed_languages', []);
+        if (!is_array($allowed) || $allowed === []) {
+            $allowed = self::getAvailableLanguages();
+        }
+
+        $available = self::getAvailableLanguages();
+        $labels = config('app.available_locales', []);
+
+        $options = [];
+        foreach ($allowed as $locale) {
+            if (!in_array($locale, $available, true)) {
+                continue;
+            }
+            $options[$locale] = $labels[$locale] ?? strtoupper($locale);
+        }
+
+        return $options !== [] ? $options : self::getAvailableLanguageOptions();
     }
 
     public static function tax(?User $user = null)

--- a/app/Helpers/NotificationHelper.php
+++ b/app/Helpers/NotificationHelper.php
@@ -97,7 +97,9 @@ class NotificationHelper
             'user_id' => $user->id,
             'title' => BladeCompiler::render($notification->in_app_title, $data),
             'body' => BladeCompiler::render($notification->in_app_body, $data),
-            'url' => isset($notification->in_app_url) ? BladeCompiler::render($notification->in_app_url, $data) : null,
+            'url' => filled($notification->in_app_url)
+                ? BladeCompiler::render($notification->in_app_url, $data)
+                : null,
             'show_in_app' => $show_in_app,
             'show_as_push' => $show_as_push,
         ]);
@@ -116,14 +118,42 @@ class NotificationHelper
             return;
         }
 
-        $userPreference = $user->notificationsPreferences()->where('notification_template_id', $notification->id)->first();
+        $locale = $data['locale'] ?? null;
 
-        if ($notification->isEnabledForPreference($userPreference, 'mail') && !config('settings.mail_disable')) {
-            self::sendEmailNotification($notification, $data, $user, $attachments);
+        if (! is_string($locale) || $locale === '') {
+            $locale = $user->preferred_language;
         }
 
-        if ($notification->isEnabledForPreference($userPreference, 'app')) {
-            self::sendInAppNotification($notification, $data, $user, $show_in_app, $show_as_push);
+        if (! is_string($locale) || $locale === '') {
+            $locale = config('app.locale');
+            if (app()->bound('session')) {
+                try {
+                    $sessionLocale = session()->get('locale');
+                    if (is_string($sessionLocale) && $sessionLocale !== '') {
+                        $locale = $sessionLocale;
+                    }
+                } catch (\Throwable) {
+                    // Queues / tests may lack an encryptable session — keep preferred/config locale.
+                }
+            }
+        }
+
+        $previousLocale = app()->getLocale();
+        app()->setLocale($locale);
+
+        try {
+            $resolved = $notification->resolveForLocale($locale);
+            $userPreference = $user->notificationsPreferences()->where('notification_template_id', $notification->id)->first();
+
+            if ($notification->isEnabledForPreference($userPreference, 'mail') && !config('settings.mail_disable')) {
+                self::sendEmailNotification($resolved, $data, $user, $attachments);
+            }
+
+            if ($notification->isEnabledForPreference($userPreference, 'app')) {
+                self::sendInAppNotification($resolved, $data, $user, $show_in_app, $show_as_push);
+            }
+        } finally {
+            app()->setLocale($previousLocale);
         }
     }
 

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -5,15 +5,26 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Auth;
 
 class SetLocale
 {
     public function handle(Request $request, Closure $next)
     {
-        if (session()->has('locale')) {
-            $locale = session()->get('locale');
-            App::setLocale($locale);
+        $locale = session('locale');
+
+        if (! is_string($locale) || $locale === '') {
+            $preferred = Auth::user()?->preferred_language;
+            if (is_string($preferred) && $preferred !== '') {
+                $locale = $preferred;
+            }
         }
+
+        if (! is_string($locale) || $locale === '') {
+            $locale = (string) config('app.locale');
+        }
+
+        App::setLocale($locale);
 
         return $next($request);
     }

--- a/app/Livewire/Client/Account.php
+++ b/app/Livewire/Client/Account.php
@@ -2,10 +2,12 @@
 
 namespace App\Livewire\Client;
 
+use App\Classes\Settings;
 use App\Helpers\NotificationHelper;
 use App\Livewire\ComponentWithProperties;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 class Account extends ComponentWithProperties
 {
@@ -15,6 +17,8 @@ class Account extends ComponentWithProperties
 
     public string $email = '';
 
+    public ?string $preferred_language = null;
+
     public function mount()
     {
         $user = Auth::user();
@@ -22,22 +26,28 @@ class Account extends ComponentWithProperties
         $this->first_name = $user->first_name;
         $this->last_name = $user->last_name;
         $this->email = $user->email;
+        $this->preferred_language = $user->preferred_language ?: config('app.locale');
 
         $this->initializeProperties($user, $user::class);
     }
 
     public function rules()
     {
+        $allowed = array_keys(Settings::getAllowedLanguageOptions());
+
         return array_merge([
             'first_name' => 'required|string|max:255',
             'last_name' => 'required|string|max:255',
             'email' => 'required|email|max:255|unique:users,email,' . Auth::id(),
+            'preferred_language' => ['required', 'string', Rule::in($allowed)],
         ], $this->getRulesForProperties());
     }
 
     public function validationAttributes()
     {
-        return $this->getAttributesForProperties();
+        return array_merge([
+            'preferred_language' => __('general.input.preferred_language'),
+        ], $this->getAttributesForProperties());
     }
 
     public function submit()
@@ -55,6 +65,11 @@ class Account extends ComponentWithProperties
             NotificationHelper::emailVerificationNotification($user);
         }
 
+        if ($user->wasChanged('preferred_language')) {
+            session(['locale' => $user->preferred_language]);
+            app()->setLocale($user->preferred_language);
+        }
+
         if (array_key_exists('properties', $validatedData)) {
             $this->updateProperties($user, $validatedData['properties']);
         }
@@ -64,7 +79,9 @@ class Account extends ComponentWithProperties
 
     public function render()
     {
-        return view('client.account.index')->layoutData([
+        return view('client.account.index', [
+            'languageOptions' => Settings::getAllowedLanguageOptions(),
+        ])->layoutData([
             'sidebar' => true,
             'title' => 'Account',
         ]);

--- a/app/Livewire/Components/LocaleSwitch.php
+++ b/app/Livewire/Components/LocaleSwitch.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Components;
 use App\Classes\Cart;
 use App\Livewire\Component;
 use App\Models\Currency;
+use Illuminate\Support\Facades\Auth;
 
 class LocaleSwitch extends Component
 {
@@ -16,7 +17,10 @@ class LocaleSwitch extends Component
 
     public function mount()
     {
-        $this->currentLocale = session('locale', config('app.locale'));
+        $this->currentLocale = session(
+            'locale',
+            Auth::user()?->preferred_language ?: config('app.locale')
+        );
         $this->currentCurrency = session('currency', config('settings.default_currency'));
         $this->currencies = Currency::all()->map(fn ($currency) => [
             'value' => $currency->code,
@@ -59,6 +63,10 @@ class LocaleSwitch extends Component
 
         session(['locale' => $locale]);
         app()->setLocale($locale);
+
+        if (Auth::check()) {
+            Auth::user()->update(['preferred_language' => $locale]);
+        }
 
         return $this->redirect(request()->header('Referer', '/'), navigate: true);
     }

--- a/app/Mail/Mail.php
+++ b/app/Mail/Mail.php
@@ -18,18 +18,37 @@ class Mail extends Mailable
 
     public array $data = [];
 
+    /**
+     * Kept for listeners (e.g. ticket reply headers). Rendering uses resolved strings.
+     */
     public NotificationTemplate $emailTemplate;
 
     /**
+     * Resolved subject template (captured before queue serialization).
+     */
+    public string $resolvedSubject;
+
+    /**
+     * Resolved body template (captured before queue serialization).
+     */
+    public string $resolvedBody;
+
+    /**
      * Create a new message instance.
+     *
+     * Subject/body are stored as plain strings so queued workers do not reload
+     * untranslated base columns from the database.
      */
     public function __construct(
         NotificationTemplate $emailTemplate,
         array $data = []
     ) {
         $this->emailTemplate = $emailTemplate;
+        $this->resolvedSubject = (string) $emailTemplate->subject;
+        $this->resolvedBody = (string) $emailTemplate->body;
         $this->data = $data;
-        $this->data['body'] = $this->emailTemplate->body;
+        $this->data['body'] = $this->resolvedBody;
+        $this->data['emailTemplate'] = $emailTemplate;
     }
 
     /**
@@ -38,7 +57,7 @@ class Mail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: BladeCompiler::render($this->emailTemplate->subject, $this->data),
+            subject: BladeCompiler::render($this->resolvedSubject, $this->data),
         );
     }
 

--- a/app/Models/NotificationTemplate.php
+++ b/app/Models/NotificationTemplate.php
@@ -4,11 +4,24 @@ namespace App\Models;
 
 use App\Enums\NotificationEnabledStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use OwenIt\Auditing\Contracts\Auditable;
 
 class NotificationTemplate extends Model implements Auditable
 {
     use HasFactory, Traits\Auditable;
+
+    /**
+     * @var list<string>
+     */
+    protected static array $translatableFields = [
+        'subject',
+        'body',
+        'in_app_title',
+        'in_app_body',
+        'in_app_url',
+        'edit_preference_message',
+    ];
 
     protected $fillable = [
         'key',
@@ -22,6 +35,7 @@ class NotificationTemplate extends Model implements Auditable
         'in_app_enabled',
         'in_app_title',
         'in_app_body',
+        'in_app_url',
         'edit_preference_message',
     ];
 
@@ -33,9 +47,137 @@ class NotificationTemplate extends Model implements Auditable
         'in_app_enabled' => NotificationEnabledStatus::class,
     ];
 
+    /**
+     * @return HasMany<NotificationPreference, $this>
+     */
     public function preferences()
     {
         return $this->hasMany(NotificationPreference::class);
+    }
+
+    /**
+     * @return HasMany<NotificationTemplateTranslation, $this>
+     */
+    public function translations(): HasMany
+    {
+        return $this->hasMany(NotificationTemplateTranslation::class);
+    }
+
+    /**
+     * Return a template instance with translated content for the given locale.
+     *
+     * Fallback order: exact locale → app locale → base template columns.
+     */
+    public function resolveForLocale(?string $locale = null): self
+    {
+        $locale = $locale ?: (string) config('app.locale');
+        $fallbackLocale = (string) config('app.locale');
+
+        $translation = $this->findTranslation($locale);
+
+        if (!$translation && $locale !== $fallbackLocale) {
+            $translation = $this->findTranslation($fallbackLocale);
+        }
+
+        if (!$translation) {
+            return $this;
+        }
+
+        $resolved = $this->newInstance([], true);
+        $resolved->exists = true;
+        $resolved->setRawAttributes($this->getAttributes());
+        $resolved->setRelations($this->relations);
+
+        foreach (self::$translatableFields as $field) {
+            $value = $translation->{$field};
+
+            if ($value !== null) {
+                $resolved->setAttribute($field, $value);
+            }
+        }
+
+        return $resolved;
+    }
+
+    protected function findTranslation(string $locale): ?NotificationTemplateTranslation
+    {
+        if ($this->relationLoaded('translations')) {
+            return $this->translations->firstWhere('locale', $locale);
+        }
+
+        return $this->translations()->where('locale', $locale)->first();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function translatableFields(): array
+    {
+        return self::$translatableFields;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function defaultLocaleAttributes(): array
+    {
+        $attributes = [];
+
+        foreach (self::$translatableFields as $field) {
+            $attributes[$field] = $this->getAttribute($field);
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function attributesForLocale(string $locale, string $defaultLocale): array
+    {
+        if ($locale === $defaultLocale) {
+            return $this->defaultLocaleAttributes();
+        }
+
+        $translation = $this->findTranslation($locale);
+
+        if (!$translation) {
+            $empty = [];
+            foreach (self::$translatableFields as $field) {
+                $empty[$field] = null;
+            }
+
+            return $empty;
+        }
+
+        $attributes = [];
+        foreach (self::$translatableFields as $field) {
+            $attributes[$field] = $translation->{$field};
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Locales that have content for this template (default language + stored translations).
+     *
+     * @return list<string>
+     */
+    public function availableLocales(): array
+    {
+        $defaultLocale = (string) config('app.locale');
+
+        $translationLocales = $this->relationLoaded('translations')
+            ? $this->translations->pluck('locale')->all()
+            : $this->translations()->pluck('locale')->all();
+
+        $others = array_values(array_filter(
+            $translationLocales,
+            static fn (string $locale): bool => $locale !== $defaultLocale
+        ));
+        sort($others, SORT_STRING);
+
+        return [$defaultLocale, ...$others];
     }
 
     public function isEmailUserControllable()

--- a/app/Models/NotificationTemplateTranslation.php
+++ b/app/Models/NotificationTemplateTranslation.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NotificationTemplateTranslation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'notification_template_id',
+        'locale',
+        'subject',
+        'body',
+        'in_app_title',
+        'in_app_body',
+        'in_app_url',
+        'edit_preference_message',
+    ];
+
+    /**
+     * @return BelongsTo<NotificationTemplate, $this>
+     */
+    public function notificationTemplate(): BelongsTo
+    {
+        return $this->belongsTo(NotificationTemplate::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -34,6 +34,7 @@ class User extends Authenticatable implements Auditable, FilamentUser, HasAvatar
         'first_name',
         'last_name',
         'email',
+        'preferred_language',
         'password',
         'role_id',
         'tfa_secret',

--- a/database/migrations/2026_07_28_220000_create_notification_template_translations_table.php
+++ b/database/migrations/2026_07_28_220000_create_notification_template_translations_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notification_template_translations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('notification_template_id');
+            $table->string('locale', 16);
+            $table->string('subject');
+            $table->text('body');
+            $table->string('in_app_title')->nullable();
+            $table->text('in_app_body')->nullable();
+            $table->string('in_app_url')->nullable();
+            $table->string('edit_preference_message')->nullable();
+            $table->timestamps();
+
+            $table->foreign('notification_template_id', 'ntt_template_id_foreign')
+                ->references('id')
+                ->on('notification_templates')
+                ->cascadeOnDelete();
+            $table->unique(['notification_template_id', 'locale'], 'notification_template_locale_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_template_translations');
+    }
+};

--- a/database/migrations/2026_07_29_005700_add_preferred_language_to_users_table.php
+++ b/database/migrations/2026_07_29_005700_add_preferred_language_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('preferred_language', 16)->nullable()->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('preferred_language');
+        });
+    }
+};

--- a/lang/de/general.php
+++ b/lang/de/general.php
@@ -9,6 +9,7 @@ return [
         'last_name_placeholder' => 'Dein Nachname',
         'email' => 'E-Mail',
         'email_placeholder' => 'Deine E-Mail-Adresse',
+        'preferred_language' => 'Bevorzugte Sprache',
         'phone' => 'Telefon',
         'phone_placeholder' => 'Deine Telefonnummer',
         'company_name' => 'Firmenname',

--- a/lang/en/general.php
+++ b/lang/en/general.php
@@ -9,6 +9,7 @@ return [
         'last_name_placeholder' => 'Your last name',
         'email' => 'Email',
         'email_placeholder' => 'Your email address',
+        'preferred_language' => 'Preferred language',
         'phone' => 'Phone',
         'phone_placeholder' => 'Your phone number',
         'company_name' => 'Company name',

--- a/themes/default/views/client/account/index.blade.php
+++ b/themes/default/views/client/account/index.blade.php
@@ -12,6 +12,13 @@
             <x-form.input name="email" type="email" :label="__('general.input.email')"
                 :placeholder="__('general.input.email_placeholder')" required wire:model="email" dirty />
 
+            <x-form.select name="preferred_language" :label="__('general.input.preferred_language')" required
+                wire:model="preferred_language" dirty>
+                @foreach ($languageOptions as $code => $label)
+                    <option value="{{ $code }}" @selected($preferred_language === $code)>{{ $label }}</option>
+                @endforeach
+            </x-form.select>
+
             <x-form.properties :custom_properties="$custom_properties" :properties="$properties" dirty />
         </div>
 


### PR DESCRIPTION
## Summary

Notification templates (email and in-app) support per-locale content in the admin UI. Users can store a preferred language on their account. That preference is used when resolving which template locale to send, including for queued and background notifications where no session is available.

## Data model

- Table `notification_template_translations` stores per-template, per-locale fields:
  - `subject`
  - `body`
  - `in_app_title`
  - `in_app_body`
  - `in_app_url`
  - `edit_preference_message`
- Columns on `notification_templates` hold the default-language content and act as fallback
- Column `users.preferred_language` stores the user’s preferred locale (nullable)

## Admin UI

### Edit notification template

- Language dropdown (allowed languages only)
- Starts on the application default language
- Optional action: **Prefill from default language** (fills the form from default content; does not save until Save)
- For a non-default locale, empty subject and body on save remove that locale’s translation row (runtime falls back to default)

### Notification templates list

- Language badges show locales that have content
- Default language first, then other locales alphabetically
- At most five badges; additional locales are shown via a `[...]` badge with a tooltip
- All badges use the same style (uppercase locale codes)

## Locale resolution for notifications

When sending a notification:

1. Explicit `$data['locale']` if provided
2. `user.preferred_language`
3. Session `locale` when available
4. Application default language (`app_language` / `config('app.locale')`)

`NotificationTemplate::resolveForLocale()` then loads the matching translation, or falls back to the base template content.

## Preferred language

- Account page: preferred language select (allowed languages)
- Locale switcher (authenticated): updates session and `preferred_language`
- `SetLocale` middleware: session → preferred language → app default
- Admin user edit: preferred language field

## Known limitation

Guest locale changes are stored only in the session. Login does not copy `session('locale')` into `users.preferred_language`. The preference is written only when an authenticated user changes language (locale switcher or Account page).

| Situation | Result |
|-----------|--------|
| Same browser/session after login | UI may keep the guest language via session |
| `preferred_language` in the database | Unchanged |
| New session / other device / cleared cookies | Uses stored preference or app default, not the earlier guest choice |

## Settings helpers (`App\Classes\Settings`)

### Visibility change

- `getAvailableLanguages()` was previously **`private`** and only used inside `Settings` for the Default Language / Allowed Languages settings UI
- It is now **`public static`** so other code (admin notification edit, Account page, User resource) can reuse the same `lang/*` directory scan without duplicating that logic

### New helpers

- `getAvailableLanguageOptions()` – maps installed locale codes to display labels from `config('app.available_locales')` (falls back to uppercase code)
- `getAllowedLanguageOptions()` – same mapping, restricted to `settings.allowed_languages` (intersected with installed locales)

These helpers feed language dropdowns and validation for allowed locales across admin and client UIs.

## Mail queue safety

`App\Mail\Mail` captures the resolved subject and body as plain strings before the message is queued, so queue workers do not reload untranslated base columns from the database.