### PR TITLE
Display credit balance in navbar/account page and fix credits_enabled enforcement

### DIFF
--- a/app/Admin/Resources/UserResource/Pages/ShowCredits.php
+++ b/app/Admin/Resources/UserResource/Pages/ShowCredits.php
@@ -66,7 +66,7 @@ class ShowCredits extends ManageRelatedRecords
             ->columns([
                 TextColumn::make('currency.code'),
                 TextColumn::make('formattedAmount')->label('Formatted Amount'),
-                TextInputColumn::make('amount')->label('Amount'),
+                TextInputColumn::make('amount')->label('Amount')->rules(['numeric', 'min:0']),
             ])
             ->filters([])
             ->headerActions([

--- a/app/Classes/Navigation.php
+++ b/app/Classes/Navigation.php
@@ -144,7 +144,7 @@ class Navigation
                                 'name' => __('account.credits'),
                                 'url' => route('account.credits'),
                                 'params' => [],
-                                'condition' => config('settings.credits_enabled'),
+                                'condition' => config('settings.credits_enabled') || config('settings.credits_payments_enabled'),
                                 'priority' => 30,
                             ],
                             [

--- a/app/Classes/Settings.php
+++ b/app/Classes/Settings.php
@@ -490,11 +490,20 @@ class Settings
             ],
             'credits' => [
                 [
-                    'name' => 'credits_enabled',
-                    'label' => 'Credits Enabled',
+                    'name' => 'credits_payments_enabled',
+                    'label' => 'Credits enabled',
                     'type' => 'checkbox',
                     'database_type' => 'boolean',
                     'default' => false,
+                    'description' => 'Allow customers to pay with credits at checkout. Disabling this does not disable existing balances from being visible, but prevents them from being spent.',
+                ],
+                [
+                    'name' => 'credits_enabled',
+                    'label' => 'Credits topup enabled',
+                    'type' => 'checkbox',
+                    'database_type' => 'boolean',
+                    'default' => false,
+                    'description' => 'Allow customers to add (top up) credits to their account. Disabling this does not prevent existing balances from being spent.',
                 ],
                 [
                     'name' => 'credits_minimum_deposit',

--- a/app/Livewire/Client/Credits.php
+++ b/app/Livewire/Client/Credits.php
@@ -9,6 +9,8 @@ use App\Livewire\Component;
 use App\Models\Credit;
 use App\Models\Gateway;
 use App\Models\Invoice;
+use App\Models\InvoiceItem;
+use App\Models\InvoiceTransaction;
 use Exception;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -29,6 +31,12 @@ class Credits extends Component
 
     public $gateway;
 
+    #[Locked]
+    public $totalAdded = [];
+
+    #[Locked]
+    public $totalSpent = [];
+
     public function mount()
     {
         $this->amount = config('settings.credits_minimum_deposit');
@@ -37,6 +45,25 @@ class Credits extends Component
         if (count($this->gateways) > 0 && !array_search($this->gateway, array_column($this->gateways, 'id')) !== false) {
             $this->gateway = $this->gateways[0]->id;
         }
+
+        $this->totalAdded = InvoiceItem::query()
+            ->join('invoices', 'invoice_items.invoice_id', '=', 'invoices.id')
+            ->where('invoices.user_id', Auth::id())
+            ->where('invoices.status', 'paid')
+            ->where('invoice_items.reference_type', Credit::class)
+            ->selectRaw('invoices.currency_code, sum(invoice_items.price * invoice_items.quantity) as total')
+            ->groupBy('invoices.currency_code')
+            ->pluck('total', 'currency_code')
+            ->toArray();
+
+        $this->totalSpent = InvoiceTransaction::query()
+            ->join('invoices', 'invoice_transactions.invoice_id', '=', 'invoices.id')
+            ->where('invoices.user_id', Auth::id())
+            ->where('invoice_transactions.is_credit_transaction', true)
+            ->selectRaw('invoices.currency_code, sum(invoice_transactions.amount) as total')
+            ->groupBy('invoices.currency_code')
+            ->pluck('total', 'currency_code')
+            ->toArray();
     }
 
     public function updated($variable)

--- a/app/Livewire/Invoices/Show.php
+++ b/app/Livewire/Invoices/Show.php
@@ -100,7 +100,7 @@ class Show extends Component
         }
 
         if ($this->selectedMethod === 'credit') {
-            if (!config('settings.credits_enabled')) {
+            if (!config('settings.credits_payments_enabled')) {
                 return $this->notify(__('Paying with credits is currently disabled.'), 'error');
             }
 

--- a/app/Livewire/Invoices/Show.php
+++ b/app/Livewire/Invoices/Show.php
@@ -100,6 +100,10 @@ class Show extends Component
         }
 
         if ($this->selectedMethod === 'credit') {
+            if (!config('settings.credits_enabled')) {
+                return $this->notify(__('Paying with credits is currently disabled.'), 'error');
+            }
+
             return $this->payWithCredit();
         }
 

--- a/app/Livewire/Services/Upgrade.php
+++ b/app/Livewire/Services/Upgrade.php
@@ -209,13 +209,15 @@ class Upgrade extends Component
 
                 $user = User::where('id', Auth::id())->lockForUpdate()->first();
                 $credit = $user->credits()->where('currency_code', $price->currency->code)->first();
+                $maxCredit = config('settings.credits_maximum_credit');
 
                 if ($credit) {
-                    $credit->increment('amount', abs($price->price));
+                    $credit->amount = min($credit->amount + abs($price->price), $maxCredit);
+                    $credit->save();
                 } else {
                     $user->credits()->create([
                         'currency_code' => $price->currency->code,
-                        'amount' => abs($price->price),
+                        'amount' => min(abs($price->price), $maxCredit),
                     ]);
                 }
 

--- a/app/Services/Invoice/ProcessPaidInvoiceService.php
+++ b/app/Services/Invoice/ProcessPaidInvoiceService.php
@@ -37,13 +37,15 @@ class ProcessPaidInvoiceService
                 $user = $invoice->user;
                 $credit = $user->credits()->where('currency_code', $invoice->currency_code)->first();
 
+                $maxCredit = config('settings.credits_maximum_credit');
+
                 if ($credit) {
-                    $credit->amount += $item->price;
+                    $credit->amount = min($credit->amount + $item->price, $maxCredit);
                     $credit->save();
                 } else {
                     $user->credits()->create([
                         'currency_code' => $invoice->currency_code,
-                        'amount' => $item->price,
+                        'amount' => min($item->price, $maxCredit),
                     ]);
                 }
             }

--- a/lang/en/account.php
+++ b/lang/en/account.php
@@ -51,6 +51,11 @@ return [
     'no_credit' => 'You have no credits.',
     'add_credit' => 'Add credit',
     'credit_deposit' => 'Credit deposit (:currency)',
+    'current_balance' => 'Current balance',
+    'total_added' => 'Total added',
+    'total_added_description' => 'Total credits added to your account',
+    'total_spent' => 'Total spent',
+    'total_spent_description' => 'Total credits spent on invoices',
 
     'payment_methods' => 'Payment Methods',
     'recent_transactions' => 'Recent Transactions',

--- a/themes/default/views/client/account/credits.blade.php
+++ b/themes/default/views/client/account/credits.blade.php
@@ -3,16 +3,47 @@
     <div class="px-2">
         <h4 class="text-2xl font-bold pb-3">{{ __('account.credits') }}</h4>
         @if (Auth::user()->credits->count() > 0)
-        <div class="flex flex-wrap gap-4">
-            @foreach (Auth::user()->credits as $credit)
-            <div class="flex flex-col bg-background-secondary w-fit rounded-lg px-5 p-3 items-center gap-1">
-                <h5 class="text-lg font-bold">{{ $credit->currency->code }}</h5>
-                <p class="text-primary-100">{{ $credit->formattedAmount }}</p>
+        <div class="mt-4 grid gap-4 md:grid-cols-3 mb-8">
+            <div class="flex flex-col gap-1 bg-background-secondary p-4 rounded-lg">
+                <span class="text-xl font-semibold">{{ __('account.credits') }}</span>
+                <span class="text-gray-500">{{ __('account.current_balance') }}</span>
+                <span class="text-2xl font-semibold mt-1">
+                    <ul>
+                        @foreach (Auth::user()->credits as $credit)
+                        <li>{{ $credit->formattedAmount }} {{ $credit->currency->code }}</li>
+                        @endforeach
+                    </ul>
+                </span>
             </div>
-            @endforeach
+            <div class="flex flex-col gap-1 bg-background-secondary p-4 rounded-lg">
+                <span class="text-xl font-semibold">{{ __('account.total_added') }}</span>
+                <span class="text-gray-500">{{ __('account.total_added_description') }}</span>
+                <span class="text-2xl font-semibold mt-1 text-gray-500">
+                    <ul>
+                        @forelse ($totalAdded as $currencyCode => $amount)
+                        <li>{{ number_format($amount, 2) }} {{ $currencyCode }}</li>
+                        @empty
+                        <li>-</li>
+                        @endforelse
+                    </ul>
+                </span>
+            </div>
+            <div class="flex flex-col gap-1 bg-background-secondary p-4 rounded-lg">
+                <span class="text-xl font-semibold">{{ __('account.total_spent') }}</span>
+                <span class="text-gray-500">{{ __('account.total_spent_description') }}</span>
+                <span class="text-2xl font-semibold mt-1 text-gray-500">
+                    <ul>
+                        @forelse ($totalSpent as $currencyCode => $amount)
+                        <li>{{ number_format($amount, 2) }} {{ $currencyCode }}</li>
+                        @empty
+                        <li>-</li>
+                        @endforelse
+                    </ul>
+                </span>
+            </div>
         </div>
         @else
-        <p>{{ __('account.no_credit') }}</p>
+        <p class="mb-8">{{ __('account.no_credit') }}</p>
         @endif
 
         <h4 class="text-xl font-bold pb-3">{{ __('account.add_credit') }}</h4>

--- a/themes/default/views/components/navigation/index.blade.php
+++ b/themes/default/views/components/navigation/index.blade.php
@@ -76,7 +76,7 @@
                                 <span class="text-sm text-base break-words">{{ auth()->user()->name }}</span>
                                 <span class="text-sm text-base break-words">{{ auth()->user()->email }}</span>
                             </div>
-                            @if(config('settings.credits_enabled') && auth()->user()->credits->count() > 0)
+                            @if((config('settings.credits_enabled') || config('settings.credits_payments_enabled')) && auth()->user()->credits->count() > 0)
                             <x-navigation.link :href="route('account.credits')" class="justify-between">
                                 <span>
                                     {{ __('account.credits') }}
@@ -216,7 +216,7 @@
                                                 <span class="text-sm text-base/70">{{ auth()->user()->email }}</span>
                                             </div>
                                         </div>
-                                        @if(config('settings.credits_enabled') && auth()->user()->credits->count() > 0)
+                                        @if((config('settings.credits_enabled') || config('settings.credits_payments_enabled')) && auth()->user()->credits->count() > 0)
                                         <x-navigation.link :href="route('account.credits')" class="justify-between p-0! mt-4">
                                             <span class="flex items-center gap-2">
                                                 <x-ri-coin-line class="size-4" />

--- a/themes/default/views/components/navigation/index.blade.php
+++ b/themes/default/views/components/navigation/index.blade.php
@@ -76,6 +76,18 @@
                                 <span class="text-sm text-base break-words">{{ auth()->user()->name }}</span>
                                 <span class="text-sm text-base break-words">{{ auth()->user()->email }}</span>
                             </div>
+                            @if(config('settings.credits_enabled') && auth()->user()->credits->count() > 0)
+                            <x-navigation.link :href="route('account.credits')" class="justify-between">
+                                <span>
+                                    {{ __('account.credits') }}
+                                </span>
+                                <span class="text-base/70">
+                                    @foreach(auth()->user()->credits as $credit)
+                                    {{ $credit->formattedAmount }}@if(!$loop->last), @endif
+                                    @endforeach
+                                </span>
+                            </x-navigation.link>
+                            @endif
                             @foreach (\App\Classes\Navigation::getAccountDropdownLinks() as $nav)
                             <x-navigation.link :href="$nav['url']" :spa="isset($nav['spa']) ? $nav['spa'] : true">
                                 {{ $nav['name'] }}
@@ -204,6 +216,17 @@
                                                 <span class="text-sm text-base/70">{{ auth()->user()->email }}</span>
                                             </div>
                                         </div>
+                                        @if(config('settings.credits_enabled') && auth()->user()->credits->count() > 0)
+                                        <x-navigation.link :href="route('account.credits')" class="justify-between p-0! mt-4">
+                                            <span class="flex items-center gap-2">
+                                                <x-ri-coin-line class="size-4" />
+                                                {{ __('account.credits') }}
+                                            </span>
+                                            <span class="text-base/70">
+                                                {{ auth()->user()->credits->map(fn($credit) => $credit->formattedAmount)->implode(', ') }}
+                                            </span>
+                                        </x-navigation.link>
+                                        @endif
                                         <div class="h-px w-full bg-neutral my-6"></div>
                                         <div class="mt-4 flex flex-col gap-2 w-full">
                                             @foreach (\App\Classes\Navigation::getAccountDropdownLinks() as $nav)

--- a/themes/default/views/invoices/partials/payment-options.blade.php
+++ b/themes/default/views/invoices/partials/payment-options.blade.php
@@ -7,7 +7,7 @@
     ->first();
     $itemHasCredit = $invoice->items()->where('reference_type', App\Models\Credit::class)->exists();
     @endphp
-    @if(config('settings.credits_enabled') && $credit && !$itemHasCredit)
+    @if(config('settings.credits_payments_enabled') && $credit && !$itemHasCredit)
     <div class="mb-6">
         <h3 class="text-lg font-semibold mb-2">{{ __('invoices.pay_with_credits') }}</h3>
         <div wire:click="$set('selectedMethod', 'credit')"

--- a/themes/default/views/invoices/partials/payment-options.blade.php
+++ b/themes/default/views/invoices/partials/payment-options.blade.php
@@ -7,7 +7,7 @@
     ->first();
     $itemHasCredit = $invoice->items()->where('reference_type', App\Models\Credit::class)->exists();
     @endphp
-    @if($credit && !$itemHasCredit)
+    @if(config('settings.credits_enabled') && $credit && !$itemHasCredit)
     <div class="mb-6">
         <h3 class="text-lg font-semibold mb-2">{{ __('invoices.pay_with_credits') }}</h3>
         <div wire:click="$set('selectedMethod', 'credit')"


### PR DESCRIPTION
Fixes `credits_enabled` still letting customers pay with credits at checkout even when the setting was unchecked, and fixes the balance not respecting the max credit cap. Also adds a navbar balance display and added/spent totals on the account credits page, and fixes the broken layout of the previous account credits page.