### PR TITLE
fix: Move encrypted flag to updateOrCreate values for VAPID keys

### DIFF
--- a/app/Classes/Settings.php
+++ b/app/Classes/Settings.php
@@ -735,12 +735,12 @@ class Settings
         try {
             $vapid = VAPID::createVapidKeys();
             Setting::updateOrCreate(
-                ['key' => 'vapid_public_key', 'encrypted' => true],
-                ['value' => $vapid['publicKey']]
+                ['key' => 'vapid_public_key'],
+                ['value' => $vapid['publicKey'], 'encrypted' => true]
             );
             Setting::updateOrCreate(
-                ['key' => 'vapid_private_key', 'encrypted' => true],
-                ['value' => $vapid['privateKey']]
+                ['key' => 'vapid_private_key'],
+                ['value' => $vapid['privateKey'], 'encrypted' => true]
             );
 
             return true;


### PR DESCRIPTION
## Summary

In `Settings::validateOrCreateVapidKeys()`, the `'encrypted' => true` flag is placed in the first argument of `updateOrCreate` (the match criteria) instead of the second (the values to write).

This makes the query `WHERE key = 'vapid_public_key' AND encrypted = 1` — if a row with that key already exists but has `encrypted = 0`, the match fails and a **duplicate row** is created.

## Current behavior

Currently harmless because the function only runs when the keys do not exist yet (the length check at the top returns early), so the duplicate-creation path is never reached in practice.

## The fix

Move `'encrypted' => true` from the first argument to the second for both `vapid_public_key` and `vapid_private_key`. This matches the pattern used in `EditExtension.php`, `EditServer.php`, and `EditGateway.php`, which all pass `'encrypted' => $option['encrypted'] ?? false` in the update values.