### PR TITLE
Add 'expires_at' translation to services

### DIFF
--- a/lang/ar/services.php
+++ b/lang/ar/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price مرة واحدة',
     'renews_in' => 'Renews in',
     'renews_on' => 'Renews on',
+    'expires_at' => 'تنتهي في',
     'auto_pay' => 'دفع تلقائي بإستخدام',
     'auto_pay_not_configured' => 'لم يتم الإعداد',
 

--- a/lang/bn/services.php
+++ b/lang/bn/services.php
@@ -55,5 +55,5 @@ return [
     'every_period' => 'Every :period :unit',
     'price_every_period' => ':price per :period :unit',
     'price_one_time' => ':price one time',
-    'expires_at' => 'Expires at',
+    'expires_at' => 'মেয়াদ শেষ হয়',
 ];

--- a/lang/da/services.php
+++ b/lang/da/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':pris en gang',
     'renews_in' => 'Fornys om',
     'renews_on' => 'Fornyer den',
+    'expires_at' => 'Udløber den',
     'auto_pay' => 'Automatisk betaling med',
     'auto_pay_not_configured' => 'Ikke konfigureret',
 

--- a/lang/de/services.php
+++ b/lang/de/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price einmal',
     'renews_in' => 'Wird erneuert in',
     'renews_on' => 'Wird erneuert am',
+    'expires_at' => 'Läuft ab am',
     'auto_pay' => 'Automatische Zahlung mit',
     'auto_pay_not_configured' => 'Nicht konfiguriert',
 

--- a/lang/en/services.php
+++ b/lang/en/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price one time',
     'renews_in' => 'Renews in',
     'renews_on' => 'Renews on',
+    'expires_at' => 'Expires at',
     'auto_pay' => 'Auto paying using',
     'auto_pay_not_configured' => 'Not configured',
 

--- a/lang/es/services.php
+++ b/lang/es/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price una sola vez',
     'renews_in' => 'Renueva en',
     'renews_on' => 'Se renueva él',
+    'expires_at' => 'Expira el',
     'auto_pay' => 'Auto pago usando',
     'auto_pay_not_configured' => 'No configurado',
 

--- a/lang/fi/services.php
+++ b/lang/fi/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price kerran',
     'renews_in' => 'Uusiutuu',
     'renews_on' => 'Uusiutuu',
+    'expires_at' => 'Vanhenee',
     'auto_pay' => 'Automaattimaksut käyttäen',
     'auto_pay_not_configured' => 'Ei määritelty',
 

--- a/lang/fr/services.php
+++ b/lang/fr/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => 'Paiement unique de :price',
     'renews_in' => 'Renouvellement dans',
     'renews_on' => 'Renouvelé le',
+    'expires_at' => 'Expire le',
     'auto_pay' => 'Renouvellement automatique en utilisant',
     'auto_pay_not_configured' => '(non configuré)',
 

--- a/lang/he/services.php
+++ b/lang/he/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price one time',
     'renews_in' => 'Renews in',
     'renews_on' => 'Renews on',
+    'expires_at' => 'פג תוקף ב',
     'auto_pay' => 'Auto paying using',
     'auto_pay_not_configured' => 'Not configured',
 

--- a/lang/hi/services.php
+++ b/lang/hi/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price one time',
     'renews_in' => 'Renews in',
     'renews_on' => 'Renews on',
+    'expires_at' => 'समाप्ति तिथि',
     'auto_pay' => 'Auto paying using',
     'auto_pay_not_configured' => 'Not configured',
 

--- a/lang/hu/services.php
+++ b/lang/hu/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price one time',
     'renews_in' => 'Renews in',
     'renews_on' => 'Megújul ekkor:',
+    'expires_at' => 'Lejár ekkor:',
     'auto_pay' => 'Automatikus fizetés a következővel:',
     'auto_pay_not_configured' => 'Nincs konfigurálva',
 

--- a/lang/id/services.php
+++ b/lang/id/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price sekali',
     'renews_in' => 'Diperpanjang dalam',
     'renews_on' => 'Diperpanjang dalam',
+    'expires_at' => 'Berakhir pada',
     'auto_pay' => 'Pembayaran otomatis menggunakan',
     'auto_pay_not_configured' => 'Belum dikonfigurasi',
 

--- a/lang/it/services.php
+++ b/lang/it/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price una volta',
     'renews_in' => 'Si rinnova in',
     'renews_on' => 'Si rinnova il',
+    'expires_at' => 'Scade il',
     'auto_pay' => 'Pagamento automatico tramite',
     'auto_pay_not_configured' => 'Non configurato',
 

--- a/lang/ko/services.php
+++ b/lang/ko/services.php
@@ -53,5 +53,5 @@ return [
     ],
     'every_period' => 'Every :period :unit',
     'price_every_period' => ':price per :period :unit',
-    'expires_at' => 'Expires at',
+    'expires_at' => '만료일',
 ];

--- a/lang/lv/services.php
+++ b/lang/lv/services.php
@@ -53,5 +53,5 @@ return [
     ],
     'every_period' => 'Every :period :unit',
     'price_every_period' => ':price per :period :unit',
-    'expires_at' => 'Expires at',
+    'expires_at' => 'Beidzas',
 ];

--- a/lang/nl/services.php
+++ b/lang/nl/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price one time',
     'renews_in' => 'Renews in',
     'renews_on' => 'Renews on',
+    'expires_at' => 'Verloopt op',
     'auto_pay' => 'Auto paying using',
     'auto_pay_not_configured' => 'Not configured',
 

--- a/lang/no/services.php
+++ b/lang/no/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price en gang',
     'renews_in' => 'Fornyes om',
     'renews_on' => 'Fornyes den',
+    'expires_at' => 'Utløper den',
     'auto_pay' => 'Automatisk betaling med',
     'auto_pay_not_configured' => 'Ikke konfigurert',
 

--- a/lang/pl/services.php
+++ b/lang/pl/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price one time',
     'renews_in' => 'Renews in',
     'renews_on' => 'Renews on',
+    'expires_at' => 'Wygasa dnia',
     'auto_pay' => 'Auto paying using',
     'auto_pay_not_configured' => 'Not configured',
 

--- a/lang/pt/services.php
+++ b/lang/pt/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price única vez',
     'renews_in' => 'Renews in',
     'renews_on' => 'Renews on',
+    'expires_at' => 'Expira em',
     'auto_pay' => 'Pagar automaticamente usando',
     'auto_pay_not_configured' => 'Não configurado',
 

--- a/lang/sr/services.php
+++ b/lang/sr/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price jednokratno',
     'renews_in' => 'Obnavlja se za',
     'renews_on' => 'Obnavlja se dana',
+    'expires_at' => 'Ističe dana',
     'auto_pay' => 'Automatsko plaćanje putem',
     'auto_pay_not_configured' => 'Nije konfigurisano',
 

--- a/lang/sv/services.php
+++ b/lang/sv/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price en gång',
     'renews_in' => 'Förnyas om',
     'renews_on' => 'Förnyas den',
+    'expires_at' => 'Går ut den',
     'auto_pay' => 'Automatisk betalning med',
     'auto_pay_not_configured' => 'Inte konfigurerad',
 

--- a/lang/tr/services.php
+++ b/lang/tr/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price one time',
     'renews_in' => 'Renews in',
     'renews_on' => 'Renews on',
+    'expires_at' => 'Son kullanma tarihi',
     'auto_pay' => 'Auto paying using',
     'auto_pay_not_configured' => 'Not configured',
 

--- a/lang/uk/services.php
+++ b/lang/uk/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => ':price один раз',
     'renews_in' => 'Поновлення через',
     'renews_on' => 'Продовжується до',
+    'expires_at' => 'Закінчується',
     'auto_pay' => 'Автоматична оплата за допомогою',
     'auto_pay_not_configured' => 'Не налаштовано',
 

--- a/lang/zh/services.php
+++ b/lang/zh/services.php
@@ -57,6 +57,7 @@ return [
     'price_one_time' => '單次費用 :price',
     'renews_in' => '續訂剩餘時間：',
     'renews_on' => '續訂於',
+    'expires_at' => '到期於',
     'auto_pay' => '自動支付方式：',
     'auto_pay_not_configured' => '未設定',
 


### PR DESCRIPTION
Add the missing 'expires_at' translation key to services.php for multiple locales (ar, bn, da, de, en, es, fi, fr, he, hi, hu, id, it, ko, lv, nl, no, pl, pt, sr, sv, tr, uk, zh) so UIs can display expiration dates in each language.