### PR TITLE
fix: email log cleanup cron deletes notifications instead of email logs

### DIFF
--- a/app/Console/Commands/CronJob.php
+++ b/app/Console/Commands/CronJob.php
@@ -8,8 +8,8 @@ use App\Jobs\Server\SuspendJob;
 use App\Jobs\Server\TerminateJob;
 use App\Models\CronStat;
 use App\Models\DebugLog;
+use App\Models\EmailLog;
 use App\Models\Invoice;
-use App\Models\Notification;
 use App\Models\Service;
 use App\Models\ServiceUpgrade;
 use App\Models\Setting;
@@ -213,9 +213,9 @@ class CronJob extends Command
             });
 
             $this->runCronJob('email_logs_deleted', function ($number = 0) {
-                $number = Notification::where('created_at', '<', now()->subDays((int) config('settings.cronjob_delete_email_logs', 90)))->count();
+                $number = EmailLog::where('created_at', '<', now()->subDays((int) config('settings.cronjob_delete_email_logs', 90)))->count();
                 // Delete email logs older then x
-                Notification::where('created_at', '<', now()->subDays((int) config('settings.cronjob_delete_email_logs', 90)))->delete();
+                EmailLog::where('created_at', '<', now()->subDays((int) config('settings.cronjob_delete_email_logs', 90)))->delete();
 
                 return $number;
             });


### PR DESCRIPTION
## Problem

The `email_logs_deleted` cron job is driven by the **"Delete email logs older than x days"** setting (`cronjob_delete_email_logs`), and its comment says it deletes email logs — but the code queries the `Notification` model:

```php
$this->runCronJob('email_logs_deleted', function ($number = 0) {
    $number = Notification::where('created_at', '<', now()->subDays((int) config('settings.cronjob_delete_email_logs', 90)))->count();
    // Delete email logs older then x
    Notification::where('created_at', '<', now()->subDays((int) config('settings.cronjob_delete_email_logs', 90)))->delete();

    return $number;
});
```

Consequences:

- `email_logs` is never cleaned up and grows without bound.
- In-app notifications older than the configured number of days (default 90) are silently deleted, even though no setting mentions notification retention.

## Fix

Point the job at the `EmailLog` model, matching the job name, the setting and the comment. The `email_logs` table has `timestamps()`, so the `created_at` filter works unchanged. `Notification` has no other usage in this file, so its import is replaced.