### PR TITLE
fix: resolve cart item prices against the cart's locked currency

### DIFF
--- a/app/Livewire/Cart.php
+++ b/app/Livewire/Cart.php
@@ -126,6 +126,11 @@ class Cart extends Component
             }
             // Lock the orderproducts
             foreach ($cart->items as $item) {
+                // An item without a price row in the cart's currency would otherwise check out free.
+                if (!$item->price->available) {
+                    throw new DisplayException(__('product.not_available', ['product' => $item->product->name]));
+                }
+
                 // Make sure we have the latest product data and lock it
                 $product = Product::where('id', $item->product->id)->lockForUpdate()->first();
 

--- a/app/Models/CartItem.php
+++ b/app/Models/CartItem.php
@@ -46,17 +46,24 @@ class CartItem extends Model
     {
         return Attribute::make(
             get: function () {
+                // Resolve against the cart's currency: the invoice inherits it, while the session may have expired back to the default currency.
+                $currency = $this->cart?->currency_code ?? session('currency', config('settings.default_currency'));
                 $total = 0;
                 $setup_fee = 0;
-                $total += $this->plan->price()->price;
-                $setup_fee += $this->plan->price()->setup_fee;
-                $this->product->configOptions->each(function ($option) use (&$total, &$setup_fee) {
+                $unavailable = false;
+                $total += $this->plan->price($currency)->price;
+                $setup_fee += $this->plan->price($currency)->setup_fee;
+                $this->product->configOptions->each(function ($option) use (&$total, &$setup_fee, &$unavailable, $currency) {
                     $selected = (object) collect($this->config_options)->firstWhere('option_id', $option->id);
 
                     // If checkbox and selected, add price of first child (only one)
                     if ($option->type === 'checkbox' && $selected?->value) {
-                        $total += $option->children->first()?->price(billing_period: $this->plan->billing_period, billing_unit: $this->plan->billing_unit)->price;
-                        $setup_fee += $option->children->first()?->price(billing_period: $this->plan->billing_period, billing_unit: $this->plan->billing_unit)->setup_fee;
+                        $childPrice = $option->children->first()?->price(billing_period: $this->plan->billing_period, billing_unit: $this->plan->billing_unit, currency: $currency);
+                        if ($childPrice) {
+                            $unavailable = $unavailable || !$childPrice->available;
+                            $total += $childPrice->price;
+                            $setup_fee += $childPrice->setup_fee;
+                        }
 
                         return;
                     }
@@ -72,13 +79,22 @@ class CartItem extends Model
                         return;
                     }
 
-                    $total += $option->children->where('id', $selected?->value)->first()?->price(billing_period: $this->plan->billing_period, billing_unit: $this->plan->billing_unit)->price;
-                    $setup_fee += $option->children->where('id', $selected?->value)->first()?->price(billing_period: $this->plan->billing_period, billing_unit: $this->plan->billing_unit)->setup_fee;
+                    $childPrice = $option->children->where('id', $selected?->value)->first()?->price(billing_period: $this->plan->billing_period, billing_unit: $this->plan->billing_unit, currency: $currency);
+                    if ($childPrice) {
+                        $unavailable = $unavailable || !$childPrice->available;
+                        $total += $childPrice->price;
+                        $setup_fee += $childPrice->setup_fee;
+                    }
                 });
+
+                // A paid option without a price row must make the whole item unavailable, not contribute 0.
+                if ($unavailable) {
+                    return new Price((object) ['price' => null, 'setup_fee' => null, 'currency' => null]);
+                }
 
                 $price = new Price([
                     'price' => $total,
-                    'currency' => $this->plan->price()->currency,
+                    'currency' => $this->plan->price($currency)->currency,
                     'setup_fee' => $setup_fee,
                 ], apply_exclusive_tax: true);
 

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -54,6 +54,11 @@ class Plan extends Model implements Auditable
         $currency = $currency ?? session('currency', config('settings.default_currency'));
         $price = $this->prices->where('currency_code', $currency)->first();
 
+        // No price row in this currency: return unavailable instead of dereferencing null.
+        if (!$price) {
+            return new PriceClass((object) ['price' => null, 'setup_fee' => null, 'currency' => null]);
+        }
+
         return new PriceClass((object) [
             'price' => $price,
             'setup_fee' => $price->setup_fee,

--- a/app/Models/Traits/HasPlans.php
+++ b/app/Models/Traits/HasPlans.php
@@ -44,18 +44,24 @@ trait HasPlans
             'currency' => null,
         ];
 
+        // Plan lookups must filter by the same currency the price is resolved in.
+        $currency = $currency ?? session('currency', config('settings.default_currency'));
+
         // Check for free plan
-        if ($this->availablePlans()->where('type', 'free')->isNotEmpty()) {
+        if ($this->availablePlans($currency)->where('type', 'free')->isNotEmpty()) {
             return new Price(free: true, dontShowUnavailablePrice: $this->dontShowUnavailablePrice ?? false);
         }
 
         // If plan_id is not provided, and billing_period is provided, get the first plan with the billing period and time interval
         if (!$plan_id && $billing_period && $billing_unit) {
-            $plan = $this->availablePlans()->where('billing_period', $billing_period)->where('billing_unit', $billing_unit)->first();
+            $plan = $this->availablePlans($currency)->where('billing_period', $billing_period)->where('billing_unit', $billing_unit)->first();
             $plan_id = $plan->id ?? null;
-        }
 
-        $currency = $currency ?? session('currency', config('settings.default_currency'));
+            // The loop below is period-agnostic and would substitute another billing period's price.
+            if (!$plan_id) {
+                return new Price($priceAndCurrency, dontShowUnavailablePrice: $this->dontShowUnavailablePrice ?? false);
+            }
+        }
 
         foreach ($this->availablePlans(currency: $currency)->when($plan_id, function ($query) use ($plan_id) {
             return $query->where('id', $plan_id);

--- a/lang/en/product.php
+++ b/lang/en/product.php
@@ -20,6 +20,7 @@ return [
 
     'in_stock' => 'In stock',
     'out_of_stock' => 'Product :product is out of stock',
+    'not_available' => ':product is not available in your currency',
     'user_limit' => 'You have reached the limit of :product',
     'payment_method' => 'Payment method',
     'use_credits' => 'Use credits',

--- a/tests/Feature/CartCurrencyTest.php
+++ b/tests/Feature/CartCurrencyTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Cart;
+use App\Models\Currency;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CartCurrencyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $product = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->product = $this->createProduct();
+    }
+
+    private function makeCartWithItem(string $currency): Cart
+    {
+        $cart = Cart::create(['currency_code' => $currency]);
+        $cart->items()->create([
+            'product_id' => $this->product->product->id,
+            'plan_id' => $this->product->plan->id,
+            'config_options' => [],
+            'checkout_config' => [],
+            'quantity' => 1,
+        ]);
+
+        return $cart->fresh();
+    }
+
+    public function test_item_price_follows_cart_currency_when_session_diverges(): void
+    {
+        Currency::create(['code' => 'EUR', 'name' => 'Euro', 'suffix' => 'EUR', 'format' => '1.000,00']);
+        $this->product->plan->prices()->create([
+            'price' => 100.00,
+            'currency_code' => 'EUR',
+        ]);
+
+        // Cart stamped USD, then the session diverges (e.g. expired back to the default currency).
+        $cart = $this->makeCartWithItem('USD');
+        session(['currency' => 'EUR']);
+
+        $price = $cart->items->first()->price;
+
+        $this->assertEquals('USD', $price->currency->code);
+        $this->assertEquals(10.00, (float) $price->price);
+    }
+
+    public function test_item_without_price_row_in_cart_currency_is_unavailable(): void
+    {
+        Currency::create(['code' => 'EUR', 'name' => 'Euro', 'suffix' => 'EUR', 'format' => '1.000,00']);
+
+        // Cart locked to EUR, but the plan is only priced in USD: must be unavailable, not free.
+        $cart = $this->makeCartWithItem('EUR');
+
+        session(['currency' => 'USD']);
+
+        $price = $cart->items->first()->price;
+
+        $this->assertFalse($price->available);
+        $this->assertEquals(0.0, (float) $price->price);
+    }
+}


### PR DESCRIPTION
## Summary

Cart line amounts are resolved from `session('currency')` at checkout time, while the order/invoice/service are created with the **cart's** `currency_code` (stamped once at cart creation — and the cart cookie lives 30 days, far longer than the session). When the session expires and falls back to `settings.default_currency`, a returning visitor with a surviving cart gets invoiced **default-currency amounts labeled with the cart's currency**.

This is not theoretical — it hit a production store last week: a customer added a plan priced at **3.99 EUR / 39.00 SEK** to a SEK-stamped cart, came back the next day after his session had expired, and checked out. The invoice (and the gateway charge) came out as **3.99 SEK** — the EUR amount with the SEK label, a 90% accidental discount. No coupon involved; every guard in `CheckoutParameterMiddleware`/`LocaleSwitch` only blocks *active* currency switches while the cart has items, so none of them catches the silent session-expiry fallback.

## What this PR does

- **`CartItem::price()`** resolves the plan price **and** the config-option child prices against `$this->cart->currency_code` (session only as fallback when the item has no cart). The invoice inherits the cart's currency, so the amounts must come from it too.
- **`Plan::price()`** returns an unavailable `Price` (currency `null` → `available === false`, renders "Not available in your currency") instead of dereferencing `null` when no price row exists for the resolved currency.
- **`HasPlans::price()`** filters its plan lookups by the same currency it prices in. Previously, when a `currency:` argument was passed but the billing-period lookup (which used session currency) found nothing, the fallback loop silently priced a **different billing period** (repro: a yearly config option priced at the monthly rate). It now reports unavailable instead.
- **`Cart::checkout()`** refuses items whose price is unavailable in the cart's currency. Previously such items resolved to price `0` and checked out **free** while still being provisioned.
- New `lang/en/product.php` key `not_available` for the checkout error.

## Tests

`tests/Feature/CartCurrencyTest.php` — two regression tests, both **fail on current master and pass with this fix**:

1. `test_item_price_follows_cart_currency_when_session_diverges` — cart stamped USD, session flipped to EUR: the item must price at the USD row with USD currency.
2. `test_item_without_price_row_in_cart_currency_is_unavailable` — cart locked to a currency the plan has no row for: the item must resolve `available === false` instead of silently pricing 0.

Full suite run before/after: the only delta is the two new tests going red → green (the handful of pre-existing failures in my environment are `ViteManifestNotFoundException` render tests, identical on clean master).

The `CartItem`/`Plan` changes have also been running patched on a production v1.5.7 store, verified against its live data (multi-currency EUR/SEK with priced config options).

## Relation to earlier work

- #1255 proposed resolving cart prices against the cart's locked currency and was closed as superseded by 9a66ebf — but 9a66ebf only adds the availability redirect on the **product page** (`Products/Checkout::mount`); the cart/checkout path it doesn't touch is where the invoice amounts are written, and the incident above happened on a version that includes 9a66ebf.
- #1277 reported the 500 when no price row exists in the session currency; the `Plan::price()` null-guard here fixes that class of crash as well.