### PR TITLE
fix(invoices): don't let invoice notification failures roll back recorded payments

### DIFF
--- a/app/Observers/InvoiceObserver.php
+++ b/app/Observers/InvoiceObserver.php
@@ -5,6 +5,7 @@ namespace App\Observers;
 use App\Events\Invoice as InvoiceEvent;
 use App\Models\Invoice;
 use App\Services\Invoice\ProcessPaidInvoiceService;
+use Illuminate\Support\Facades\DB;
 
 class InvoiceObserver
 {

--- a/app/Observers/InvoiceObserver.php
+++ b/app/Observers/InvoiceObserver.php
@@ -44,8 +44,10 @@ class InvoiceObserver
     public function updated(Invoice $invoice): void
     {
         if ($invoice->isDirty('status') && $invoice->status == 'paid') {
+            DB::afterCommit(function () use ($invoice) {
             app(ProcessPaidInvoiceService::class)->handle($invoice);
             event(new InvoiceEvent\Paid($invoice));
+            });
         }
         event(new InvoiceEvent\Updated($invoice));
     }


### PR DESCRIPTION
## Summary

Since v1.5.7, a failure anywhere in the invoice-paid notification chain **rolls back the payment record itself**. The gateway keeps the money, Paymenter keeps no record of it, and because the webhook returns a 500, gateways (eg Stripe) tend to send out retries, re-firing notifications each time for a payment that no longer exists in the database.

This is a regression introduced in https://github.com/Paymenter/Paymenter/commit/39bc14fb28929a790deafebd90e0ac2521a9cb9b

## Root cause

39bc14fb wrapped `ExtensionHelper::addPayment()` in `DB::transaction()` with `lockForUpdate()`. That was a reasonable fix for a race condition, but the transaction now encloses a chain of side effects that were never transactional:

```
ExtensionHelper::addPayment()
  DB::transaction {
    $invoice->transactions()->updateOrCreate(...)          // INSERT
      -> InvoiceTransactionObserver::created
        -> InvoiceTransactionCreatedListener               // $invoice->status = 'paid'; save()
          -> InvoiceObserver::updated
            -> ProcessPaidInvoiceService::handle()         // renews the service
            -> event(InvoiceEvent\Paid)
              -> SendMailListener
                -> NotificationHelper::invoiceNotification()
                  -> PDF::generateInvoice() + $pdf->save() // synchronous filesystem write
  }
```

`$pdf->save()` is a synchronous `file_put_contents` to `storage/app/invoices/`. If it throws (in case of unwritable directory, disk full, a dompdf error on unusual invoice content), the exception unwinds out of the transaction closure, Laravel rolls back, and both the transaction row and the paid status are discarded.

Nothing about rendering the PDF should be able to void a financial record, so we argue this is a reasonable solution. Although it might be worth to catch and define this as an error. 


## Impact

- Payment taken by the gateway, no record in Paymenter. The invoice stays `pending`.
- The service is not renewed, so the customer can be dunned or suspended for an invoice they already paid.
- The webhook returns 500, so the gateway retries on its backoff schedule for days.
- Notifications dispatch **inside** the transaction and are not rolled back, so each retry emits a fresh "invoice paid" notification for a payment that does not exist. Any external notifier (Discord, webhooks) reports paid invoices and renewed services that were rolled back milliseconds later.

Any gateway using `addPayment` is affected- this is not Stripe-specific.

## Reproduction

1. Make `storage/app/invoices/` unwritable by the web/php-fpm user.
2. Pay an invoice via any gateway that confirms by webhook.
3. Observe: the gateway shows the payment succeeded; the invoice remains `pending` with no transaction row; `laravel.log` shows `file_put_contents(...): Failed to open stream: Permission denied` with the trace ending in `ExtensionHelper::addPayment`; the gateway begins retrying the webhook.

A realistic way to reach this unintentionally: run the scheduler as `root` while php-fpm runs as `www-data`. Cron writes the invoice PDF first and owns the file; the webhook process then cannot overwrite it.

## Evidence that this is a regression

This issue was examined when analyzing a customer on an instance that has billed them through multiple versions, same service, same monthly renewal, saved card on billing agreement through Stripe shown one monthly payment cycle apart between v1.5.3 and 1.5.7. 

**v1.5.3** — the failure occurs after the payment is committed:

```
#4  NotificationHelper.php(153): PDF->save()
...
#38 ExtensionHelper.php(495): HasOneOrMany->updateOrCreate()
#39 Stripe.php(227): ExtensionHelper::addPayment()
```

Result: invoice **paid**, service renewed, only the receipt email lost.

**v1.5.7** — identical failure, five frames deeper:

```
#4  NotificationHelper.php(153): PDF->save()
...
#39 ExtensionHelper.php(498): HasOneOrMany->updateOrCreate()
#40 ManagesTransactions.php(35): ExtensionHelper::{closure}()
#41 DatabaseManager.php(491): Connection->transaction()
#42 Facade.php(363): DatabaseManager->__call()
#43 ExtensionHelper.php(474): Facade::__callStatic()
#44 Stripe.php(238): ExtensionHelper::addPayment()
```

Result: invoice **still pending**, no transaction row, service not renewed, webhook retried for hours.

Three pre-upgrade occurrences of this exact error (PayPal, Stripe) all left their invoices correctly paid. Every post-upgrade occurrence rolls back. The only difference is the transaction wrapper.

## Proposed fix

Keep the transaction around the database writes, that part of https://github.com/Paymenter/Paymenter/commit/39bc14fb28929a790deafebd90e0ac2521a9cb9b is correct, and defer the side effects until after commit. The codebase already uses this pattern in https://github.com/Paymenter/Paymenter/blob/master/app/Console/Commands/CronJob.php#L102, which wraps its billing-agreement charge in `DB::afterCommit()`.

In `InvoiceObserver::updated()`:

```php
if ($invoice->isDirty('status') && $invoice->status == 'paid') {
    DB::afterCommit(function () use ($invoice) {
        app(ProcessPaidInvoiceService::class)->handle($invoice);
        event(new InvoiceEvent\Paid($invoice));
    });
}
```

`DB::afterCommit()` runs the callback immediately when no transaction is active, so behaviour outside `addPayment` is unchanged. Provisioning and notifying only after the payment is durably committed is also the correct ordering on its own merits.

An alternative or complementary approach is to make `SendMailListener` implement `ShouldQueue` with `$afterCommit = true`, which additionally moves synchronous PDF rendering out of the webhook request.

## Notes

Happy to adjust the patch if maintainers prefer a different boundary, the most important part is that a payment recorded from a gateway callback must not be undone by a rendering or notification failure. I left this PR as draft for now to check if there's an additional change needed for cron which might've resulted in the underlying filesystem permission error with the PDFs that made me find this regression. I'm waiting on a test payment to generate normally with cron. I'm almost certain I applied permissions correctly to the /var/www/paymenter directory last time I interacted with it (confirmed by bash history). 