### PR TITLE
Update Product & Filters for API

### DIFF
--- a/app/Http/Controllers/Api/Admin/CategoryController.php
+++ b/app/Http/Controllers/Api/Admin/CategoryController.php
@@ -15,7 +15,7 @@ use Spatie\QueryBuilder\QueryBuilder;
 class CategoryController extends ApiController
 {
     protected const INCLUDES = [
-        'products',
+        'products.plans.prices',
         'parent',
         'children',
     ];
@@ -29,7 +29,7 @@ class CategoryController extends ApiController
     {
         // Fetch categories with pagination
         $categories = QueryBuilder::for(Category::class)
-            ->allowedFilters(['name', 'parent_id'])
+            ->allowedFilters(['name', 'parent_id', 'slug'])
             ->allowedIncludes($this->allowedIncludes(self::INCLUDES))
             ->allowedSorts(['id', 'created_at', 'updated_at', 'name'])
             ->simplePaginate(request('per_page', 15));

--- a/app/Http/Controllers/Api/Admin/ProductController.php
+++ b/app/Http/Controllers/Api/Admin/ProductController.php
@@ -29,7 +29,7 @@ class ProductController extends ApiController
     {
         // Fetch products with pagination
         $products = QueryBuilder::for(Product::class)
-            ->allowedFilters(['name', 'category_id', 'server_id', 'hidden', 'allow_quantity'])
+            ->allowedFilters(['name', 'slug', 'category_id', 'server_id', 'hidden', 'allow_quantity'])
             ->allowedIncludes($this->allowedIncludes(self::INCLUDES))
             ->allowedSorts(['id', 'created_at', 'updated_at', 'name', 'sort', 'stock'])
             ->simplePaginate(request('per_page', 15));


### PR DESCRIPTION
These changes allow product fetching by slug and add the ability to include products and pricing of these products when fetching by category preventing the need to make a pricing call for each individual product in a category. 