### PR TITLE
fix: staff with only View Services can't open any service

### DIFF
--- a/app/Admin/Resources/Common/RelationManagers/PropertiesRelationManager.php
+++ b/app/Admin/Resources/Common/RelationManagers/PropertiesRelationManager.php
@@ -3,6 +3,8 @@
 namespace App\Admin\Resources\Common\RelationManagers;
 
 use App\Models\CustomProperty;
+use App\Models\Service;
+use App\Support\ServiceAdminAuthorization;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
@@ -15,6 +17,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Columns\TextInputColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
 
 class PropertiesRelationManager extends RelationManager
 {
@@ -35,6 +38,11 @@ class PropertiesRelationManager extends RelationManager
             ]);
     }
 
+    public function isReadOnly(): bool
+    {
+        return !$this->canWriteOwner();
+    }
+
     public function table(Table $table): Table
     {
         return $table
@@ -43,22 +51,50 @@ class PropertiesRelationManager extends RelationManager
                 TextColumn::make('name'),
                 TextColumn::make('parent_property.name'),
                 TextColumn::make('key'),
-                TextInputColumn::make('value'),
+                $this->isReadOnly()
+                    ? TextColumn::make('value')
+                    : TextInputColumn::make('value')
+                        ->updateStateUsing(function (Model $record, mixed $state): mixed {
+                            abort_unless($this->canWriteOwner(), 403);
+                            $record->update(['value' => $state]);
+
+                            return $state;
+                        }),
             ])
             ->filters([
                 //
             ])
             ->headerActions([
-                CreateAction::make(),
+                CreateAction::make()
+                    ->authorize(fn (): bool => $this->canWriteOwner()),
             ])
             ->recordActions([
-                EditAction::make(),
-                DeleteAction::make(),
+                EditAction::make()
+                    ->authorize(fn (): bool => $this->canWriteOwner()),
+                DeleteAction::make()
+                    ->authorize(fn (): bool => $this->canWriteOwner()),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorize(fn (): bool => $this->canWriteOwner()),
                 ]),
             ]);
+    }
+
+    protected function canWriteOwner(): bool
+    {
+        $owner = $this->getOwnerRecord();
+        $user = auth()->user();
+
+        if (!$owner instanceof Model || !$user) {
+            return false;
+        }
+
+        if ($owner instanceof Service) {
+            return ServiceAdminAuthorization::canUpdate($user, $owner);
+        }
+
+        return $user->can('update', $owner);
     }
 }

--- a/app/Admin/Resources/ServiceResource.php
+++ b/app/Admin/Resources/ServiceResource.php
@@ -14,6 +14,7 @@ use App\Helpers\ExtensionHelper;
 use App\Models\Currency;
 use App\Models\Product;
 use App\Models\Service;
+use App\Support\ServiceAdminAuthorization;
 use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
@@ -137,7 +138,10 @@ class ServiceResource extends Resource
                     ->minValue(0)
                     ->hintAction(
                         Action::make('Recalculate Price')
+                            ->visible(fn (Component $component) => $component->getRecord() instanceof Service
+                                && ServiceAdminAuthorization::canUpdate(auth()->user(), $component->getRecord()))
                             ->action(function (Component $component, Service $service) {
+                                ServiceAdminAuthorization::authorizeUpdate(auth()->user(), $service);
                                 if ($service) {
                                     Notification::make('Price Recalculated')
                                         ->title('The price has been successfully recalculated')
@@ -163,7 +167,10 @@ class ServiceResource extends Resource
                     ->hintAction(
                         Action::make('Cancel Subscription ID')
                             ->action(function (Component $component) {
-                                if (ExtensionHelper::cancelSubscription($component->getRecord())) {
+                                $record = $component->getRecord();
+                                abort_unless($record instanceof Service, 403);
+                                ServiceAdminAuthorization::authorizeUpdate(auth()->user(), $record);
+                                if (ExtensionHelper::cancelSubscription($record)) {
                                     Notification::make('Subscription Cancelled')
                                         ->title('The subscription has been successfully cancelled')
                                         ->success()
@@ -175,11 +182,13 @@ class ServiceResource extends Resource
                                         ->send();
                                 }
                                 // Update the record to remove the subscription ID
-                                $component->getRecord()->update(['subscription_id' => null]);
+                                $record->update(['subscription_id' => null]);
                             })
                             ->requiresConfirmation()
                             ->label('Cancel Subscription')
-                            ->hidden(fn (Component $component) => !$component->getRecord()?->subscription_id),
+                            ->hidden(fn (Component $component) => !$component->getRecord()?->subscription_id
+                                || !($component->getRecord() instanceof Service)
+                                || !ServiceAdminAuthorization::canUpdate(auth()->user(), $component->getRecord())),
                     ),
             ]);
     }
@@ -259,7 +268,8 @@ class ServiceResource extends Resource
                     ->orderBy('id', 'desc');
             })
             ->recordActions([
-                EditAction::make(),
+                EditAction::make()
+                    ->authorize(fn (Service $record): bool => auth()->user()?->can('view', $record) ?? false),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Admin/Resources/ServiceResource/Pages/EditService.php
+++ b/app/Admin/Resources/ServiceResource/Pages/EditService.php
@@ -7,6 +7,7 @@ use App\Admin\Resources\ServiceResource;
 use App\Helpers\ExtensionHelper;
 use App\Helpers\NotificationHelper;
 use App\Models\Service;
+use App\Support\ServiceAdminAuthorization;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
@@ -14,15 +15,66 @@ use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
+use Filament\Schemas\Components\Component;
+use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Model;
 
 class EditService extends EditRecord
 {
     protected static string $resource = ServiceResource::class;
 
+    /**
+     * Staff with View Services (view/viewAny) may open this URL. Writes still
+     * require Update Services — Filament's default EditRecord gate is update-only.
+     */
+    protected function authorizeAccess(): void
+    {
+        abort_unless(ServiceAdminAuthorization::canView(auth()->user(), $this->getRecord()), 403);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return parent::form($schema)
+            ->disabled(!$this->canUpdateRecord());
+    }
+
+    protected function getFormActions(): array
+    {
+        if (!$this->canUpdateRecord()) {
+            return [
+                $this->getCancelFormAction(),
+            ];
+        }
+
+        return parent::getFormActions();
+    }
+
+    public function save(bool $shouldRedirect = true, bool $shouldSendSavedNotification = true): void
+    {
+        $this->authorizeServiceWrite();
+
+        parent::save($shouldRedirect, $shouldSendSavedNotification);
+    }
+
+    public function saveFormComponentOnly(Component $component): void
+    {
+        $this->authorizeServiceWrite();
+
+        parent::saveFormComponentOnly($component);
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        $this->authorizeServiceWrite();
+
+        return parent::handleRecordUpdate($record, $data);
+    }
+
     protected function getHeaderActions(): array
     {
         return [
             DeleteAction::make()
+                ->visible(fn () => $this->canUpdateRecord())
                 ->form(function (DeleteAction $action) {
                     $status = !in_array($this->record->status, [Service::STATUS_PENDING, Service::STATUS_CANCELLED]) && $this->record->product->server_id !== null;
                     if (!$status) {
@@ -36,6 +88,9 @@ class EditService extends EditRecord
                     ];
                 })
                 ->action(function (array $data, Service $record): void {
+                    $this->authorizeServiceWrite();
+                    abort_unless(auth()->user()?->can('delete', $record), 403);
+
                     try {
                         if (($data['deleteExtensionServer'] ?? false)) {
                             ExtensionHelper::terminateServer($record);
@@ -53,6 +108,7 @@ class EditService extends EditRecord
                 }),
             Action::make('changeStatus')
                 ->label('Trigger Extension Action')
+                ->visible(fn () => $this->canUpdateRecord())
                 ->schema([
                     Select::make('action')
                         ->label('Action')
@@ -68,6 +124,8 @@ class EditService extends EditRecord
                         ->default(false),
                 ])
                 ->action(function (array $data, Service $record, Action $action): void {
+                    $this->authorizeServiceWrite();
+
                     try {
                         switch ($data['action']) {
                             case 'create':
@@ -129,5 +187,15 @@ class EditService extends EditRecord
         return [
             ServiceResource\Widgets\CancellationOverview::class,
         ];
+    }
+
+    protected function canUpdateRecord(): bool
+    {
+        return ServiceAdminAuthorization::canUpdate(auth()->user(), $this->getRecord());
+    }
+
+    protected function authorizeServiceWrite(): void
+    {
+        ServiceAdminAuthorization::authorizeUpdate(auth()->user(), $this->getRecord());
     }
 }

--- a/app/Admin/Resources/ServiceResource/RelationManagers/ConfigOptionsRelationManager.php
+++ b/app/Admin/Resources/ServiceResource/RelationManagers/ConfigOptionsRelationManager.php
@@ -2,7 +2,9 @@
 
 namespace App\Admin\Resources\ServiceResource\RelationManagers;
 
+use App\Models\Service;
 use App\Models\ServiceConfig;
+use App\Support\ServiceAdminAuthorization;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\Select;
@@ -11,6 +13,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 class ConfigOptionsRelationManager extends RelationManager
 {
@@ -46,8 +49,31 @@ class ConfigOptionsRelationManager extends RelationManager
             ])
             ->headerActions([])
             ->recordActions([
-                EditAction::make(),
-                DeleteAction::make(),
+                EditAction::make()
+                    ->authorize(fn (): bool => $this->canWriteOwner()),
+                DeleteAction::make()
+                    ->authorize(fn (): bool => $this->canWriteOwner()),
             ]);
+    }
+
+    public function isReadOnly(): bool
+    {
+        return !$this->canWriteOwner();
+    }
+
+    protected function canWriteOwner(): bool
+    {
+        $owner = $this->getOwnerRecord();
+        $user = auth()->user();
+
+        if (!$owner instanceof Model || !$user) {
+            return false;
+        }
+
+        if ($owner instanceof Service) {
+            return ServiceAdminAuthorization::canUpdate($user, $owner);
+        }
+
+        return $user->can('update', $owner);
     }
 }

--- a/app/Policies/ServicePolicy.php
+++ b/app/Policies/ServicePolicy.php
@@ -20,7 +20,10 @@ class ServicePolicy extends BasePolicy
      */
     public function view(User $user, Service $service): bool
     {
-        return $this->adminPermission($user, 'admin.services.view') || $service->user_id === $user->id;
+        return $this->adminPermission($user, 'admin.services.view')
+            || $this->adminPermission($user, 'admin.services.viewAny')
+            || $this->adminPermission($user, 'admin.services.update')
+            || $service->user_id === $user->id;
     }
 
     /**

--- a/app/Support/ServiceAdminAuthorization.php
+++ b/app/Support/ServiceAdminAuthorization.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Service;
+use App\Models\User;
+
+/**
+ * Staff read/write checks for admin service surfaces.
+ *
+ * ServicePolicy grants staff abilities only on admin requests or Livewire
+ * updates (route-guarded in BasePolicy). These helpers also accept the raw
+ * permissions so the admin-only call sites (Filament pages and components,
+ * which are reachable solely through the admin panel) behave identically in
+ * contexts without that request state.
+ */
+class ServiceAdminAuthorization
+{
+    public static function canView(?User $user, Service $service): bool
+    {
+        if (!$user) {
+            return false;
+        }
+
+        return $user->can('view', $service)
+            || $user->hasPermission('admin.services.view')
+            || $user->hasPermission('admin.services.viewAny')
+            || $user->hasPermission('admin.services.update')
+            || $service->user_id === $user->id;
+    }
+
+    public static function canUpdate(?User $user, Service $service): bool
+    {
+        if (!$user) {
+            return false;
+        }
+
+        return $user->can('update', $service)
+            || $user->hasPermission('admin.services.update');
+    }
+
+    public static function authorizeUpdate(?User $user, Service $service): void
+    {
+        abort_unless(static::canUpdate($user, $service), 403);
+    }
+}

--- a/tests/Feature/Admin/ServiceStaffReadWriteAuthorizationTest.php
+++ b/tests/Feature/Admin/ServiceStaffReadWriteAuthorizationTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Admin\Resources\Common\RelationManagers\PropertiesRelationManager;
+use App\Admin\Resources\ServiceResource\Pages\EditService;
+use App\Models\Currency;
+use App\Models\Role;
+use App\Models\Service;
+use App\Models\User;
+use App\Support\ServiceAdminAuthorization;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ServiceStaffReadWriteAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected bool $seed = false;
+
+    private User $customer;
+
+    private Service $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Currency::firstOrCreate(['code' => 'USD'], [
+            'name' => 'US Dollar',
+            'prefix' => '$',
+            'suffix' => '',
+            'format' => '1,000.00',
+        ]);
+
+        $product = $this->createProduct();
+        $this->customer = User::factory()->create();
+        $this->service = Service::factory()->create([
+            'user_id' => $this->customer->id,
+            'product_id' => $product->product->id,
+            'plan_id' => $product->plan->id,
+            'status' => Service::STATUS_ACTIVE,
+            'currency_code' => 'USD',
+            'price' => 10.00,
+            'quantity' => 1,
+            'expires_at' => now()->addMonth(),
+        ]);
+    }
+
+    public function test_view_any_staff_can_view_but_not_update_on_admin(): void
+    {
+        $staff = $this->staff(['admin.services.viewAny']);
+        $this->actingAsStaffOnAdmin($staff);
+
+        $this->assertTrue($staff->can('view', $this->service));
+        $this->assertFalse($staff->can('update', $this->service));
+        $this->assertFalse(ServiceAdminAuthorization::canUpdate($staff, $this->service));
+    }
+
+    public function test_view_any_does_not_grant_storefront_view_of_other_users_services(): void
+    {
+        $staff = $this->staff(['admin.services.viewAny']);
+        $this->actingAs($staff);
+
+        $this->assertFalse($staff->can('view', $this->service));
+        $this->assertFalse($staff->can('update', $this->service));
+        $this->assertTrue($this->customer->can('view', $this->service));
+        $this->assertTrue($this->customer->can('update', $this->service));
+    }
+
+    public function test_view_any_staff_can_open_edit_service_but_cannot_save_or_trigger_extension(): void
+    {
+        $staff = $this->staff(['admin.services.viewAny']);
+
+        $component = Livewire::actingAs($staff)
+            ->test(EditService::class, ['record' => $this->service->getRouteKey()]);
+
+        $component->assertSuccessful();
+        $component->assertActionHidden('changeStatus');
+        $component->assertActionHidden('delete');
+
+        Livewire::actingAs($staff)
+            ->test(EditService::class, ['record' => $this->service->getRouteKey()])
+            ->call('save')
+            ->assertForbidden();
+
+        $this->assertSame(10.00, (float) $this->service->fresh()->price);
+        $this->assertSame(Service::STATUS_ACTIVE, $this->service->fresh()->status);
+    }
+
+    public function test_update_staff_can_save_service(): void
+    {
+        $staff = $this->staff(['admin.services.viewAny', 'admin.services.update']);
+
+        Livewire::actingAs($staff)
+            ->test(EditService::class, ['record' => $this->service->getRouteKey()])
+            ->fillForm([
+                'price' => 25.00,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertSame(25.00, (float) $this->service->fresh()->price);
+    }
+
+    public function test_view_any_staff_cannot_inline_edit_property_value(): void
+    {
+        $staff = $this->staff(['admin.services.viewAny']);
+        $property = $this->service->properties()->create(['key' => 'k1', 'name' => 'k1', 'value' => 'v0']);
+
+        Livewire::actingAs($staff)
+            ->test(PropertiesRelationManager::class, [
+                'ownerRecord' => $this->service,
+                'pageClass' => EditService::class,
+            ])
+            ->assertSuccessful()
+            ->call('updateTableColumnState', 'value', (string) $property->getKey(), 'v1');
+
+        $this->assertSame('v0', $property->fresh()->value);
+    }
+
+    public function test_update_staff_can_inline_edit_property_value(): void
+    {
+        $staff = $this->staff(['admin.services.viewAny', 'admin.services.update']);
+        $property = $this->service->properties()->create(['key' => 'k1', 'name' => 'k1', 'value' => 'v0']);
+
+        Livewire::actingAs($staff)
+            ->test(PropertiesRelationManager::class, [
+                'ownerRecord' => $this->service,
+                'pageClass' => EditService::class,
+            ])
+            ->assertSuccessful()
+            ->call('updateTableColumnState', 'value', (string) $property->getKey(), 'v1');
+
+        $this->assertSame('v1', $property->fresh()->value);
+    }
+
+    private function staff(array $permissions): User
+    {
+        $role = Role::create([
+            'name' => 'Staff ' . uniqid('', true),
+            'permissions' => $permissions,
+        ]);
+
+        return User::factory()->create(['role_id' => $role->id]);
+    }
+
+    private function actingAsStaffOnAdmin(User $user): void
+    {
+        $this->actingAs($user);
+        $request = Request::create('/admin/services/services/' . $this->service->id . '/edit', 'GET');
+        $request->setUserResolver(fn () => $user);
+        $this->app->instance('request', $request);
+    }
+}


### PR DESCRIPTION
### Problem

Create a staff role with only the **View Services** permission (`admin.services.viewAny`). The member can see the services table, but opening any service returns 403:

- `ServiceResource` only registers an edit page, and Filament's `EditRecord` requires the `update` ability to mount.
- `ServicePolicy::view()` checks `admin.services.view`, which `config/permissions.php` never offers (only `viewAny` is listed as "View Services"), and `User::hasPermission()` matches exactly — so no grantable permission ever satisfies it.

In practice there is no way to build a read-only support role that can look at a service.

### Changes

- `ServicePolicy::view()` accepts `admin.services.view` (kept for back-compat), `admin.services.viewAny` or `admin.services.update`, plus the existing owner check.
- `EditService` overrides `authorizeAccess()` so view-capable staff can open the existing edit URL (no new page or route). Without `update`:
  - the form renders disabled, the Save action is removed, and `save()` / `saveFormComponentOnly()` / `handleRecordUpdate()` reject server-side — hiding the button isn't enough since Livewire can still call `save`;
  - Delete and "Trigger Extension Action" are hidden and their callbacks reject;
  - the "Recalculate Price" and "Cancel Subscription" hint actions are hidden and reject;
  - the Properties relation manager becomes read-only (the inline `value` column falls back to a plain text column, and its update path re-checks), and Config Options edit/delete are gated the same way.
- New `App\Support\ServiceAdminAuthorization` centralizes the read/write checks for these admin surfaces.

Staff with Update Services keep exactly the behavior they have today; checking that box on a role turns a read-only member into a full editor with no code change.

### Tests

`tests/Feature/Admin/ServiceStaffReadWriteAuthorizationTest.php` covers both directions:

- viewAny-only staff can view but not update via the policy; storefront ownership checks are unchanged
- viewAny-only staff can mount `EditService`, write actions are hidden, `save` returns 403, and inline property edits are rejected
- update staff can save the form and inline-edit properties

Existing tests pass and Pint is clean on the touched files.
