### PR TITLE
feat: add per-unit pricing to number configurable options

### DIFF
--- a/app/Admin/Resources/ConfigOptionResource.php
+++ b/app/Admin/Resources/ConfigOptionResource.php
@@ -68,9 +68,29 @@ class ConfigOptionResource extends Resource
                             Checkbox::make('hidden')
                                 ->label('Hidden'),
                             Checkbox::make('upgradable')
-                                ->visible(fn (Get $get): bool => in_array($get('type'), ['select', 'radio', 'slider']))
+                                ->visible(fn (Get $get): bool => in_array($get('type'), ['select', 'radio', 'slider', 'number']))
                                 ->label('Upgradable')
-                                ->helperText('If enabled, this configuration option can be upgraded in the future.'),
+                                ->helperText('If enabled, this configuration option can be upgraded in the future. A number option needs a price per unit to be upgradable.'),
+                            TextInput::make('min')
+                                ->label('Minimum')
+                                ->visible(fn (Get $get): bool => $get('type') === 'number')
+                                ->numeric()
+                                ->helperText('The lowest amount a customer may enter.'),
+                            TextInput::make('max')
+                                ->label('Maximum')
+                                ->visible(fn (Get $get): bool => $get('type') === 'number')
+                                ->numeric()
+                                ->helperText('The highest amount a customer may enter.'),
+                            TextInput::make('step')
+                                ->label('Increment')
+                                ->visible(fn (Get $get): bool => $get('type') === 'number')
+                                ->numeric()
+                                ->minValue(0)
+                                ->helperText('Customers can only enter amounts in steps of this size, counted from the minimum.'),
+                            Checkbox::make('show_as_slider')
+                                ->label('Show as slider')
+                                ->visible(fn (Get $get): bool => $get('type') === 'number')
+                                ->helperText('Show a slider running from the minimum to the maximum instead of a plain input. Needs both a minimum and a maximum.'),
                             Select::make('products')
                                 ->label('Products')
                                 ->relationship('products', 'name')
@@ -79,12 +99,23 @@ class ConfigOptionResource extends Resource
                                 ->placeholder('Select the products that this configuration option belongs to'),
                         ]),
                         Tab::make('Options')
-                            ->visible(fn (Get $get): bool => in_array($get('type'), ['select', 'radio', 'slider', 'checkbox']))
+                            ->visible(fn (Get $get): bool => in_array($get('type'), ['select', 'radio', 'slider', 'checkbox', 'number']))
                             ->schema([
+                                ProductResource::plan()
+                                    ->visible(fn (Get $get): bool => $get('type') === 'number')
+                                    ->columnSpanFull()
+                                    ->label('Base Price')
+                                    ->helperText('Optional starting cost, charged on top of the price per unit.')
+                                    ->addActionLabel('Add base price')
+                                    ->reorderable(false)
+                                    ->deleteAction(null)
+                                    ->defaultItems(0)
+                                    ->minItems(0)
+                                    ->maxItems(1),
                                 Repeater::make('Options')
                                     ->relationship('children')
-                                    ->label('Options')
-                                    ->addActionLabel('Add Option')
+                                    ->label(fn (Get $get): string => $get('type') === 'number' ? 'Price per unit' : 'Options')
+                                    ->addActionLabel(fn (Get $get): string => $get('type') === 'number' ? 'Add price per unit' : 'Add Option')
                                     ->columnSpanFull()
                                     ->itemLabel(fn (array $state) => $state['name'])
                                     ->collapsible()
@@ -93,15 +124,16 @@ class ConfigOptionResource extends Resource
                                     ->reorderable()
                                     ->orderColumn('sort')
                                     ->columns(2)
-                                    // When the type is checkbox only allow 1 child
+                                    // When the type is checkbox or number only allow 1 child
                                     ->maxItems(function (Get $get): ?int {
                                         if (in_array($get('type'), ['select', 'radio', 'slider'])) {
                                             return null; // unlimited children
                                         }
 
-                                        return 1; // checkbox
+                                        return 1; // checkbox and number
                                     })
-                                    ->minItems(1)
+                                    // A number option is only priced per unit when a price is added, so it stays optional
+                                    ->minItems(fn (Get $get): int => $get('type') === 'number' ? 0 : 1)
                                     ->schema([
                                         TextInput::make('name')
                                             ->label('Name')
@@ -111,7 +143,9 @@ class ConfigOptionResource extends Resource
                                             ->placeholder('Enter the name of the configuration option'),
                                         TextInput::make('env_variable')
                                             ->label('Environment Variable')
-                                            ->required()
+                                            // A number option passes the entered amount to the server, not the name of this child
+                                            ->visible(fn (Get $get): bool => $get('../../type') !== 'number')
+                                            ->required(fn (Get $get): bool => $get('../../type') !== 'number')
                                             ->maxLength(255)
                                             ->placeholder('Enter the environment variable name'),
                                         // if the type is select, radio or checkbox then allow unlimited children (otherwise only allow 1)

--- a/app/Admin/Resources/ServiceResource/RelationManagers/ConfigOptionsRelationManager.php
+++ b/app/Admin/Resources/ServiceResource/RelationManagers/ConfigOptionsRelationManager.php
@@ -6,6 +6,7 @@ use App\Models\ServiceConfig;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
@@ -30,6 +31,12 @@ class ConfigOptionsRelationManager extends RelationManager
                     ->live()
                     ->preload()
                     ->required(),
+                TextInput::make('value')
+                    ->label('Amount')
+                    ->numeric()
+                    ->required()
+                    // Number options are priced per entered unit, so the amount decides the price
+                    ->visible(fn (?ServiceConfig $record): bool => $record?->configOption?->type === 'number'),
             ]);
     }
 
@@ -40,6 +47,9 @@ class ConfigOptionsRelationManager extends RelationManager
             ->columns([
                 TextColumn::make('configOption.name'),
                 TextColumn::make('configValue.name'),
+                TextColumn::make('value')
+                    ->label('Amount')
+                    ->placeholder('-'),
             ])
             ->filters([
                 //

--- a/app/Classes/Cart.php
+++ b/app/Classes/Cart.php
@@ -20,7 +20,7 @@ class Cart
             return new \App\Models\Cart;
         }
 
-        return $cart->load('items.plan', 'items.product', 'items.product.configOptions.children.plans.prices');
+        return $cart->load('items.plan', 'items.product', 'items.product.configOptions.plans.prices', 'items.product.configOptions.children.plans.prices');
     }
 
     public static function get()
@@ -78,7 +78,7 @@ class Cart
             'checkout_config' => $checkoutConfig,
             'quantity' => $quantity,
         ]);
-        $cart->load('items.plan', 'items.product', 'items.product.configOptions.children.plans.prices');
+        $cart->load('items.plan', 'items.product', 'items.product.configOptions.plans.prices', 'items.product.configOptions.children.plans.prices');
 
         if ($cart->coupon_id) {
             // Reapply coupon to the cart
@@ -138,7 +138,7 @@ class Cart
         if ($item) {
             $item->delete(); // We also want to trigger Eloquent events
         }
-        $cart->load('items.plan', 'items.product', 'items.product.configOptions.children.plans.prices');
+        $cart->load('items.plan', 'items.product', 'items.product.configOptions.plans.prices', 'items.product.configOptions.children.plans.prices');
     }
 
     public static function updateQuantity($index, $quantity)

--- a/app/Helpers/ExtensionHelper.php
+++ b/app/Helpers/ExtensionHelper.php
@@ -554,6 +554,12 @@ class ExtensionHelper
             $properties[$property->key] = $property->value;
         }
         foreach ($service->configs as $config) {
+            // A number option passes the amount the customer entered, not the name of the option holding its unit price
+            if ($config->configOption->type === 'number') {
+                $properties[$config->configOption->env_variable ?: $config->configOption->name] = $config->value;
+
+                continue;
+            }
             $properties[$config->configOption->env_variable] = $config->configValue->env_variable ?? $config->configValue->name;
         }
 

--- a/app/Livewire/Cart.php
+++ b/app/Livewire/Cart.php
@@ -203,6 +203,22 @@ class Cart extends Component
                         if (!isset($configOption->value)) {
                             continue;
                         }
+
+                        // A number option that is priced per unit is stored as a config so renewals keep charging for it
+                        $option = $configOption->option_type === 'number'
+                            ? $item->product->configOptions->firstWhere('id', $configOption->option_id)
+                            : null;
+
+                        if ($option?->hasUnitPricing()) {
+                            $service->configs()->create([
+                                'config_option_id' => $option->id,
+                                'config_value_id' => $option->children->first()->id,
+                                'value' => $configOption->value,
+                            ]);
+
+                            continue;
+                        }
+
                         $service->properties()->updateOrCreate([
                             'key' => $configOption->option_env_variable ? $configOption->option_env_variable : $configOption->option_name,
                         ], [

--- a/app/Livewire/Products/Checkout.php
+++ b/app/Livewire/Products/Checkout.php
@@ -65,7 +65,10 @@ class Checkout extends Component
 
             // Prepare the config options
             $this->configOptions = $this->product->configOptions->mapWithKeys(function ($option) {
-                if (in_array($option->type, ['text', 'number'])) {
+                if ($option->type === 'number') {
+                    return [$option->id => $this->configOptions[$option->id] ?? $option->min];
+                }
+                if ($option->type === 'text') {
                     return [$option->id => $this->configOptions[$option->id] ?? null];
                 }
                 if ($option->type === 'checkbox') {
@@ -102,6 +105,16 @@ class Checkout extends Component
             if ($option->type === 'checkbox' && (isset($this->configOptions[$option->id]) && $this->configOptions[$option->id])) {
                 $total += $option->children->first()?->price(billing_period: $this->plan->billing_period, billing_unit: $this->plan->billing_unit)->price;
                 $setup_fee += $option->children->first()?->price(billing_period: $this->plan->billing_period, billing_unit: $this->plan->billing_unit)->setup_fee;
+
+                return;
+            }
+            // A number option is charged per entered unit as soon as a price is attached to it
+            if ($option->type === 'number') {
+                if ($option->hasUnitPricing()) {
+                    $optionPrice = $option->priceForQuantity($this->configOptions[$option->id] ?? 0, $this->plan->billing_period, $this->plan->billing_unit);
+                    $total += $optionPrice->price;
+                    $setup_fee += $optionPrice->setup_fee;
+                }
 
                 return;
             }
@@ -154,7 +167,9 @@ class Checkout extends Component
             ],
         ];
         foreach ($this->product->configOptions as $option) {
-            if (in_array($option->type, ['text', 'number'])) {
+            if ($option->type === 'number') {
+                $rules["configOptions.{$option->id}"] = $option->numberValidationRules();
+            } elseif ($option->type === 'text') {
                 $rules["configOptions.{$option->id}"] = ['required'];
             } elseif ($option->type === 'checkbox') {
                 // No validation needed for checkbox

--- a/app/Livewire/Services/Upgrade.php
+++ b/app/Livewire/Services/Upgrade.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Services;
 
 use App\Exceptions\DisplayException;
 use App\Livewire\Component;
+use App\Models\ConfigOption;
 use App\Models\Invoice;
 use App\Models\Product;
 use App\Models\Service;
@@ -48,6 +49,33 @@ class Upgrade extends Component
         }
     }
 
+    /**
+     * Build an unsaved config for the upgrade, so the price can be quoted before anything is stored.
+     */
+    private function makeUpgradeConfig(ConfigOption $option, $value): ?ServiceConfig
+    {
+        if ($option->type === 'number') {
+            if (!is_numeric($value)) {
+                return null;
+            }
+
+            $config = new ServiceConfig([
+                'config_option_id' => $option->id,
+                'config_value_id' => $option->children->first()->id,
+                'value' => $value,
+            ]);
+        } elseif ($option->children->contains('id', $value)) {
+            $config = new ServiceConfig([
+                'config_option_id' => $option->id,
+                'config_value_id' => $value,
+            ]);
+        } else {
+            return null;
+        }
+
+        return $config->setRelation('configOption', $option);
+    }
+
     #[Computed]
     public function totalToday()
     {
@@ -62,14 +90,13 @@ class Upgrade extends Component
         // Add config options to the temporary upgrade (without saving)
         foreach ($this->configOptions as $optionId => $value) {
             $option = $this->upgradeProduct->upgradableConfigOptions->where('id', $optionId)->first();
-            if (!$option || !$option->children->contains('id', $value)) {
+            if (!$option) {
                 continue;
             }
 
-            $configs->push(new ServiceConfig([
-                'config_option_id' => $optionId,
-                'config_value_id' => $value,
-            ]));
+            if ($config = $this->makeUpgradeConfig($option, $value)) {
+                $configs->push($config);
+            }
         }
 
         $upgrade->setRelation('configs', $configs);
@@ -91,16 +118,34 @@ class Upgrade extends Component
 
     public function nextStep()
     {
-        $currentConfigOptions = $this->service->configs->pluck('config_value_id', 'config_option_id')->toArray();
+        $currentConfigOptions = $this->currentConfigOptions();
         $this->configOptions = $this->upgradeProduct->upgradableConfigOptions->mapWithKeys(function ($option) use ($currentConfigOptions) {
+            // A number option is driven by the amount the customer ordered, not by which child was picked
+            $default = $option->type === 'number' ? $option->min : $option->children->first()->id;
+
             return [
                 $option->id => $currentConfigOptions[$option->id]
                     ?? $this->configOptions[$option->id]
-                    ?? $option->children->first()->id,
+                    ?? $default,
             ];
         })->toArray();
 
         $this->step++;
+    }
+
+    /**
+     * What the service is on today, in the same shape as $configOptions so the two can be compared.
+     */
+    private function currentConfigOptions(): array
+    {
+        return $this->service->configs
+            ->filter(fn ($config) => $this->upgradeProduct->upgradableConfigOptions->contains('id', $config->config_option_id))
+            ->mapWithKeys(fn ($config) => [
+                $config->config_option_id => $config->configOption?->type === 'number'
+                    ? $config->value
+                    : $config->config_value_id,
+            ])
+            ->toArray();
     }
 
     public function rules()
@@ -121,7 +166,9 @@ class Upgrade extends Component
 
         ];
         foreach ($this->upgradeProduct->upgradableConfigOptions as $option) {
-            if (in_array($option->type, ['text', 'number'])) {
+            if ($option->type === 'number') {
+                $rules["configOptions.{$option->id}"] = $option->numberValidationRules();
+            } elseif ($option->type === 'text') {
                 $rules["configOptions.{$option->id}"] = ['required'];
             } elseif ($option->type === 'checkbox') {
             } else {
@@ -163,10 +210,7 @@ class Upgrade extends Component
                 ->first();
 
             // The old config options must be in upgradableConfigOptions
-            $serviceConfigOptions = $service->configs->pluck('config_value_id', 'config_option_id')->toArray();
-            $configOptions = collect($serviceConfigOptions)->filter(function ($value, $key) use ($serviceConfigOptions) {
-                return isset($serviceConfigOptions[$key]) && $this->upgradeProduct->upgradableConfigOptions->contains('id', $key);
-            })->toArray();
+            $configOptions = $this->currentConfigOptions();
 
             // If the product did not change and the config options are the same, present the user with a message
             if ($this->upgradeProduct->id === $service->product_id && $this->configOptions == $configOptions) {
@@ -189,10 +233,11 @@ class Upgrade extends Component
                     if (!isset($this->configOptions[$option->id])) {
                         continue;
                     }
-                    $upgrade->configs()->create([
-                        'config_option_id' => $option->id,
-                        'config_value_id' => $this->configOptions[$option->id],
-                    ]);
+                    $config = $this->makeUpgradeConfig($option, $this->configOptions[$option->id]);
+                    if (!$config) {
+                        continue;
+                    }
+                    $upgrade->configs()->create($config->only(['config_option_id', 'config_value_id', 'value']));
                 }
             }
             $price = $upgrade->calculatePrice();

--- a/app/Models/CartItem.php
+++ b/app/Models/CartItem.php
@@ -68,6 +68,18 @@ class CartItem extends Model
                         return;
                     }
 
+                    // A number option is charged per entered unit as soon as a price is attached to it
+                    if ($option->type === 'number') {
+                        if ($option->hasUnitPricing()) {
+                            $optionPrice = $option->priceForQuantity($selected->value ?? 0, $this->plan->billing_period, $this->plan->billing_unit, $currency);
+                            $unavailable = $unavailable || !$optionPrice->available;
+                            $total += $optionPrice->price;
+                            $setup_fee += $optionPrice->setup_fee;
+                        }
+
+                        return;
+                    }
+
                     // Skip text, number and checkbox types as they have no price
                     if (in_array($option->type, ['text', 'number', 'checkbox'])) {
                         $total += 0;

--- a/app/Models/ConfigOption.php
+++ b/app/Models/ConfigOption.php
@@ -2,7 +2,9 @@
 
 namespace App\Models;
 
+use App\Classes\Price as PriceClass;
 use App\Models\Traits\HasPlans;
+use Closure;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use OwenIt\Auditing\Contracts\Auditable;
 
@@ -21,6 +23,17 @@ class ConfigOption extends Model implements Auditable
         'hidden',
         'parent_id',
         'upgradable',
+        'min',
+        'max',
+        'step',
+        'show_as_slider',
+    ];
+
+    protected $casts = [
+        'min' => 'float',
+        'max' => 'float',
+        'step' => 'float',
+        'show_as_slider' => 'boolean',
     ];
 
     /**
@@ -53,5 +66,89 @@ class ConfigOption extends Model implements Auditable
     public function serviceConfigs()
     {
         return $this->hasMany(ServiceConfig::class, 'config_option_id');
+    }
+
+    /**
+     * A number option is priced per unit as soon as it has a child holding the unit price.
+     */
+    public function hasUnitPricing(): bool
+    {
+        return $this->type === 'number' && $this->children->isNotEmpty();
+    }
+
+    /**
+     * A slider needs both ends of the range to know where to start and stop.
+     */
+    public function hasSlider(): bool
+    {
+        return $this->type === 'number' && $this->show_as_slider && $this->min !== null && $this->max !== null;
+    }
+
+    /**
+     * Rules for a number option: the amount has to stay within the configured range and follow its increment.
+     */
+    public function numberValidationRules(): array
+    {
+        $rules = ['required', 'numeric'];
+
+        if ($this->min !== null) {
+            $rules[] = 'min:' . $this->min;
+        }
+        if ($this->max !== null) {
+            $rules[] = 'max:' . $this->max;
+        }
+        if ($this->step) {
+            $rules[] = function (string $attribute, $value, Closure $fail) {
+                $steps = ((float) $value - ($this->min ?? 0)) / $this->step;
+
+                if (abs($steps - round($steps)) > 0.0000001) {
+                    $fail(__('The :attribute must be in increments of :step.', ['step' => $this->step + 0]));
+                }
+            };
+        }
+
+        return $rules;
+    }
+
+    /**
+     * The price of a single unit of a number option.
+     */
+    public function unitPrice($billing_period = null, $billing_unit = null, $currency = null): ?PriceClass
+    {
+        return $this->children->first()?->price(null, $billing_period, $billing_unit, $currency);
+    }
+
+    /**
+     * The price a number option adds for the entered quantity: the optional base price of the
+     * option itself plus its unit price for every entered unit.
+     *
+     * @return object{price: float, setup_fee: float, available: bool}
+     */
+    public function priceForQuantity($quantity, $billing_period = null, $billing_unit = null, $currency = null): object
+    {
+        $quantity = max(0, (float) $quantity);
+        $total = 0;
+        $setupFee = 0;
+        $available = true;
+
+        if ($unitPrice = $this->unitPrice($billing_period, $billing_unit, $currency)) {
+            $available = $available && $unitPrice->available;
+            $total += $unitPrice->price * $quantity;
+            $setupFee += ($unitPrice->setup_fee ?? 0) * $quantity;
+        }
+
+        // The base price is optional: only options that got their own plans charge one.
+        if ($this->plans->isNotEmpty()) {
+            $basePrice = $this->price(null, $billing_period, $billing_unit, $currency);
+            $available = $available && $basePrice->available;
+            $total += $basePrice->price;
+            $setupFee += $basePrice->setup_fee ?? 0;
+        }
+
+        return (object) [
+            'price' => $total,
+            'setup_fee' => $setupFee,
+            'available' => $available,
+        ];
     }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Models\Traits\HasPlans;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -76,6 +77,12 @@ class Product extends Model implements Auditable
      */
     public function upgradableConfigOptions(): HasManyThrough
     {
-        return $this->hasManyThrough(ConfigOption::class, ConfigOptionProduct::class, 'product_id', 'id', 'id', 'config_option_id')->where('config_options.hidden', false)->where('config_options.upgradable', true)->orderBy('config_options.sort', 'asc')->orderBy('config_options.id', 'desc');
+        return $this->hasManyThrough(ConfigOption::class, ConfigOptionProduct::class, 'product_id', 'id', 'id', 'config_option_id')
+            ->where('config_options.hidden', false)
+            ->where('config_options.upgradable', true)
+            // A number option has nothing to bill for until a price per unit is attached to it
+            ->where(fn (Builder $query) => $query->where('config_options.type', '!=', 'number')->orWhereHas('children'))
+            ->orderBy('config_options.sort', 'asc')
+            ->orderBy('config_options.id', 'desc');
     }
 }

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -225,9 +225,18 @@ class Service extends Model implements Auditable
 
         $this->configs->each(function ($config) use (&$price) {
             $configValue = $config->configValue;
-            if ($configValue) {
-                $price += $configValue->price(null, $this->plan->billing_period, $this->plan->billing_unit, $this->currency_code)->price;
+            if (!$configValue) {
+                return;
             }
+
+            // A number option is charged per unit the customer ordered
+            if ($config->configOption?->type === 'number') {
+                $price += $config->configOption->priceForQuantity($config->value, $this->plan->billing_period, $this->plan->billing_unit, $this->currency_code)->price;
+
+                return;
+            }
+
+            $price += $configValue->price(null, $this->plan->billing_period, $this->plan->billing_unit, $this->currency_code)->price;
         });
 
         // Add coupon discount if applicable

--- a/app/Models/ServiceConfig.php
+++ b/app/Models/ServiceConfig.php
@@ -13,6 +13,7 @@ class ServiceConfig extends Model implements Auditable
         'service_id',
         'config_option_id',
         'config_value_id',
+        'value',
     ];
 
     /**

--- a/app/Models/ServiceUpgrade.php
+++ b/app/Models/ServiceUpgrade.php
@@ -77,9 +77,17 @@ class ServiceUpgrade extends Model implements Auditable
         $total = $this->calculateProratedAmount($this->service->product, $this->product)->price;
 
         foreach ($this->configs as $config) {
+            $oldConfig = $this->service->configs->where('config_option_id', $config->config_option_id)->first();
+
+            // A number option keeps pointing at the same child; what changes is how many units were ordered
+            if ($config->configOption?->type === 'number') {
+                $total += $this->calculateProratedQuantityAmount($oldConfig, $config)->price;
+
+                continue;
+            }
+
             if ($configValue = $config->configValue) {
-                $oldPrice = $this->service->configs->where('config_option_id', $config->config_option_id)->first();
-                $total += $this->calculateProratedAmount($oldPrice?->configValue, $configValue)->price;
+                $total += $this->calculateProratedAmount($oldConfig?->configValue, $configValue)->price;
             }
         }
 
@@ -89,6 +97,37 @@ class ServiceUpgrade extends Model implements Auditable
         }
 
         return $this->makePrice($total);
+    }
+
+    /**
+     * A number option is charged per unit, so an upgrade bills the difference in units over the remaining days.
+     * The base price sits in both amounts and cancels out, unless the option is only now being added.
+     */
+    protected function calculateProratedQuantityAmount(?ServiceConfig $oldConfig, ServiceConfig $newConfig): Price
+    {
+        $option = $newConfig->configOption;
+
+        if (!$option) {
+            return $this->makePrice();
+        }
+
+        $plan = $this->service->plan;
+
+        $newPrice = $option->priceForQuantity($newConfig->value, $plan->billing_period, $plan->billing_unit, $this->service->currency_code)->price;
+        $oldPrice = $oldConfig
+            ? $option->priceForQuantity($oldConfig->value, $plan->billing_period, $plan->billing_unit, $this->service->currency_code)->price
+            : 0;
+
+        $difference = $newPrice - $oldPrice;
+
+        if ($difference == 0 || !$this->service->expires_at) {
+            return $this->makePrice($difference);
+        }
+
+        $billingPeriodDays = $this->getBillingPeriodDays();
+        $remainingDays = $this->getRemainingDays();
+
+        return $this->makePrice($billingPeriodDays > 0 ? ($difference / $billingPeriodDays) * $remainingDays : $difference);
     }
 
     protected function resolveOldItemPrice($oldItem): float

--- a/app/Services/ServiceUpgrade/ServiceUpgradeService.php
+++ b/app/Services/ServiceUpgrade/ServiceUpgradeService.php
@@ -41,16 +41,18 @@ class ServiceUpgradeService
             // Update service configurations - remove old configs and add new ones
             $newConfigOptionIds = $serviceUpgrade->configs->pluck('config_option_id')->toArray();
 
-            // Delete configs that are no longer applicable
+            // Delete configs that are no longer applicable, except number options, which are kept
+            // because a non-upgradable one is never part of an upgrade and would otherwise be lost
             $service->configs()
                 ->whereNotIn('config_option_id', $newConfigOptionIds)
+                ->whereHas('configOption', fn ($query) => $query->where('type', '!=', 'number'))
                 ->delete();
 
             // Update or create new configs
             foreach ($serviceUpgrade->configs as $config) {
                 $service->configs()->updateOrCreate(
                     ['config_option_id' => $config->config_option_id],
-                    ['config_value_id' => $config->config_value_id]
+                    ['config_value_id' => $config->config_value_id, 'value' => $config->value]
                 );
             }
 

--- a/database/migrations/2026_08_19_120000_add_unit_pricing_to_config_options.php
+++ b/database/migrations/2026_08_19_120000_add_unit_pricing_to_config_options.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('config_options', function (Blueprint $table) {
+            $table->decimal('min', 20, 2)->nullable()->after('upgradable');
+            $table->decimal('max', 20, 2)->nullable()->after('min');
+            $table->decimal('step', 20, 2)->nullable()->after('max');
+            $table->boolean('show_as_slider')->default(false)->after('step');
+        });
+
+        Schema::table('service_configs', function (Blueprint $table) {
+            $table->string('value')->nullable()->after('config_value_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('config_options', function (Blueprint $table) {
+            $table->dropColumn(['min', 'max', 'step', 'show_as_slider']);
+        });
+
+        Schema::table('service_configs', function (Blueprint $table) {
+            $table->dropColumn('value');
+        });
+    }
+};

--- a/lang/en/product.php
+++ b/lang/en/product.php
@@ -17,6 +17,7 @@ return [
     'apply' => 'Apply',
     'price' => 'Price',
     'setup_fee' => 'Setup fee',
+    'per_unit' => 'per unit',
 
     'in_stock' => 'In stock',
     'out_of_stock' => 'Product :product is out of stock',

--- a/tests/Feature/AdminConfigOptionFormTest.php
+++ b/tests/Feature/AdminConfigOptionFormTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Admin\Resources\ConfigOptionResource\Pages\CreateConfigOption;
+use App\Admin\Resources\ConfigOptionResource\Pages\EditConfigOption;
+use App\Models\ConfigOption;
+use App\Models\Plan;
+use App\Models\Price;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AdminConfigOptionFormTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAs(User::factory()->create([
+            'role_id' => Role::where('name', 'admin')->first()->id,
+        ]));
+    }
+
+    public function test_number_option_can_be_created_with_a_price_per_unit(): void
+    {
+        Livewire::test(CreateConfigOption::class)
+            ->fillForm([
+                'name' => 'Storage',
+                'env_variable' => 'STORAGE',
+                'type' => 'number',
+                'min' => 100,
+                'max' => 5000,
+                'step' => 10,
+                'show_as_slider' => true,
+                'upgradable' => true,
+                'plan' => [
+                    [
+                        'name' => 'Base',
+                        'type' => 'recurring',
+                        'billing_period' => 1,
+                        'billing_unit' => 'month',
+                        'pricing' => [
+                            ['currency_code' => 'USD', 'price' => 2, 'setup_fee' => 0],
+                        ],
+                    ],
+                ],
+                'Options' => [
+                    [
+                        'name' => 'Price per GB',
+                        'plan' => [
+                            [
+                                'name' => 'Per GB',
+                                'type' => 'recurring',
+                                'billing_period' => 1,
+                                'billing_unit' => 'month',
+                                'pricing' => [
+                                    ['currency_code' => 'USD', 'price' => 0.05, 'setup_fee' => 0],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $option = ConfigOption::where('name', 'Storage')->first();
+
+        $this->assertNotNull($option);
+        $this->assertEquals([100.0, 5000.0, 10.0], [$option->min, $option->max, $option->step]);
+        $this->assertCount(1, $option->children);
+        $this->assertTrue($option->hasUnitPricing());
+        $this->assertTrue($option->hasSlider());
+        $this->assertTrue((bool) $option->upgradable);
+
+        // 2 (base price) + 500 * 0.05 (price per unit)
+        $this->assertEquals(27.0, $option->priceForQuantity(500, 1, 'month', 'USD')->price);
+    }
+
+    public function test_number_option_form_can_be_edited(): void
+    {
+        $option = ConfigOption::create([
+            'name' => 'Storage',
+            'env_variable' => 'STORAGE',
+            'type' => 'number',
+            'min' => 100,
+            'max' => 5000,
+            'step' => 10,
+        ]);
+        $child = ConfigOption::create([
+            'name' => 'Price per GB',
+            'type' => 'number',
+            'parent_id' => $option->id,
+        ]);
+        $plan = Plan::factory()->create([
+            'priceable_id' => $child->id,
+            'priceable_type' => ConfigOption::class,
+            'name' => 'Test Plan',
+            'billing_unit' => 'month',
+            'billing_period' => 1,
+            'type' => 'recurring',
+        ]);
+        Price::factory()->create([
+            'plan_id' => $plan->id,
+            'price' => 0.05,
+            'currency_code' => 'USD',
+        ]);
+
+        Livewire::test(EditConfigOption::class, ['record' => $option->getRouteKey()])
+            ->assertFormSet([
+                'type' => 'number',
+                'min' => 100.0,
+                'step' => 10.0,
+                'show_as_slider' => false,
+            ])
+            ->fillForm(['max' => 10000])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertEquals(10000.0, $option->refresh()->max);
+    }
+}

--- a/tests/Feature/ConfigOptionUnitPricingTest.php
+++ b/tests/Feature/ConfigOptionUnitPricingTest.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Helpers\ExtensionHelper;
+use App\Models\Cart;
+use App\Models\ConfigOption;
+use App\Models\Coupon;
+use App\Models\Currency;
+use App\Models\Plan;
+use App\Models\Price;
+use App\Models\Service;
+use App\Models\ServiceUpgrade;
+use App\Models\User;
+use App\Services\ServiceUpgrade\ServiceUpgradeService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Once;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ConfigOptionUnitPricingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $product = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->product = $this->createProduct();
+    }
+
+    /**
+     * Create a number config option charging $unitPrice for every entered unit.
+     */
+    private function createNumberOption(float $unitPrice, array $attributes = [], ?float $basePrice = null): ConfigOption
+    {
+        $option = ConfigOption::create(array_merge([
+            'name' => 'Storage',
+            'env_variable' => 'STORAGE',
+            'type' => 'number',
+            'min' => 100,
+            'max' => 5000,
+            'step' => 10,
+        ], $attributes));
+
+        $option->products()->attach($this->product->product->id);
+
+        $child = ConfigOption::create([
+            'name' => 'Price per GB',
+            'type' => 'number',
+            'parent_id' => $option->id,
+        ]);
+
+        $this->createPlanFor($child, $unitPrice);
+
+        if ($basePrice !== null) {
+            $this->createPlanFor($option, $basePrice);
+        }
+
+        return $option->refresh();
+    }
+
+    private function createPlanFor(ConfigOption $option, float $price): void
+    {
+        $plan = Plan::factory()->create([
+            'priceable_id' => $option->id,
+            'priceable_type' => ConfigOption::class,
+            'name' => 'Test Plan',
+            'billing_unit' => 'month',
+            'billing_period' => 1,
+            'type' => 'recurring',
+        ]);
+
+        Price::factory()->create([
+            'plan_id' => $plan->id,
+            'price' => $price,
+            'currency_code' => 'USD',
+        ]);
+    }
+
+    public function test_number_option_without_pricing_stays_free(): void
+    {
+        $option = ConfigOption::create([
+            'name' => 'Hostname number',
+            'env_variable' => 'NODES',
+            'type' => 'number',
+        ]);
+        $option->products()->attach($this->product->product->id);
+
+        Livewire::test('products.checkout', ['category' => $this->product->product->category, 'product' => $this->product->product->slug])
+            ->set('configOptions.' . $option->id, 8)
+            ->assertSet('total.price', 10.0);
+    }
+
+    public function test_number_option_multiplies_unit_price_by_entered_amount(): void
+    {
+        $option = $this->createNumberOption(0.75, ['name' => 'RAM', 'env_variable' => 'RAM', 'min' => 1, 'max' => 64, 'step' => 1]);
+
+        // 10 (plan) + 8 * 0.75 = 16
+        Livewire::test('products.checkout', ['category' => $this->product->product->category, 'product' => $this->product->product->slug])
+            ->assertSet('configOptions.' . $option->id, 1.0)
+            ->set('configOptions.' . $option->id, 8)
+            ->assertSet('total.price', 16.0);
+    }
+
+    public function test_number_option_adds_its_base_price_once(): void
+    {
+        $option = $this->createNumberOption(0.05, basePrice: 2.0);
+
+        // 10 (plan) + 2 (base) + 500 * 0.05 = 37
+        Livewire::test('products.checkout', ['category' => $this->product->product->category, 'product' => $this->product->product->slug])
+            ->assertSeeHtml('type="number"')
+            ->assertSeeHtml('min="100"')
+            ->assertSeeHtml('max="5000"')
+            ->assertSeeHtml('step="10"')
+            ->assertSeeText('Storage - $0.05 per unit')
+            ->set('configOptions.' . $option->id, 500)
+            ->assertSet('total.price', 37.0);
+    }
+
+    public function test_number_option_renders_a_slider_when_enabled(): void
+    {
+        $option = $this->createNumberOption(0.05, ['show_as_slider' => true]);
+
+        Livewire::test('products.checkout', ['category' => $this->product->product->category, 'product' => $this->product->product->slug])
+            ->assertSeeHtml('type="range"')
+            ->assertSeeHtml('min="100"')
+            ->assertSeeHtml('max="5000"')
+            ->assertSeeHtml('step="10"')
+            ->assertSeeText('Storage - $0.05 per unit')
+            // Dragging the slider feeds the same property the plain input uses
+            ->set('configOptions.' . $option->id, 500)
+            ->assertSet('total.price', 35.0);
+
+        $this->assertTrue($option->hasSlider());
+    }
+
+    public function test_slider_falls_back_to_an_input_without_a_full_range(): void
+    {
+        $option = $this->createNumberOption(0.05, ['show_as_slider' => true, 'max' => null]);
+
+        Livewire::test('products.checkout', ['category' => $this->product->product->category, 'product' => $this->product->product->slug])
+            ->assertDontSeeHtml('type="range"')
+            ->assertSeeHtml('type="number"');
+
+        $this->assertFalse($option->hasSlider());
+    }
+
+    public function test_number_option_rejects_amounts_outside_its_range_or_increment(): void
+    {
+        $option = $this->createNumberOption(0.05);
+
+        $component = Livewire::test('products.checkout', ['category' => $this->product->product->category, 'product' => $this->product->product->slug]);
+
+        $component->set('configOptions.' . $option->id, 50)->call('checkout')->assertHasErrors('configOptions.' . $option->id);
+        $component->set('configOptions.' . $option->id, 6000)->call('checkout')->assertHasErrors('configOptions.' . $option->id);
+        $component->set('configOptions.' . $option->id, 105)->call('checkout')->assertHasErrors('configOptions.' . $option->id);
+        $component->set('configOptions.' . $option->id, 110)->call('checkout')->assertHasNoErrors();
+    }
+
+    public function test_cart_item_keeps_charging_per_unit(): void
+    {
+        $option = $this->createNumberOption(0.05, basePrice: 2.0);
+
+        Livewire::test('products.checkout', ['category' => $this->product->product->category, 'product' => $this->product->product->slug])
+            ->set('configOptions.' . $option->id, 500)
+            ->call('checkout');
+
+        Once::flush();
+
+        $item = Cart::first()->items()->first();
+
+        $this->assertEquals(37.0, (float) $item->price->price);
+    }
+
+    public function test_ordering_stores_the_amount_on_the_service(): void
+    {
+        $option = $this->createNumberOption(0.05, basePrice: 2.0);
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        Livewire::test('products.checkout', ['category' => $this->product->product->category, 'product' => $this->product->product->slug])
+            ->set('configOptions.' . $option->id, 500)
+            ->call('checkout');
+
+        Once::flush();
+
+        Livewire::withCookie('cart', Cart::first()->ulid)->test('cart')->call('checkout');
+
+        $service = Service::first();
+
+        $this->assertNotNull($service);
+        $this->assertDatabaseHas('service_configs', [
+            'configurable_id' => $service->id,
+            'config_option_id' => $option->id,
+            'config_value_id' => $option->children->first()->id,
+            'value' => 500,
+        ]);
+
+        // 10 (plan) + 2 (base) + 500 * 0.05 = 37
+        $this->assertEquals('37.00', $service->calculatePrice());
+        $this->assertEquals(500, ExtensionHelper::getServiceProperties($service)['STORAGE']);
+    }
+
+    public function test_setup_fee_is_charged_per_unit_too(): void
+    {
+        $option = $this->createNumberOption(0.05, ['min' => 1, 'max' => 1000, 'step' => 1]);
+        // $0.10 one-off per GB on top of the recurring $0.05
+        $option->children->first()->plans->first()->prices()->update(['setup_fee' => 0.10]);
+        $option->refresh();
+
+        $price = $option->priceForQuantity(200, 1, 'month', 'USD');
+
+        $this->assertEquals(10.0, $price->price);
+        $this->assertEquals(20.0, $price->setup_fee);
+    }
+
+    public function test_an_option_without_a_price_in_the_chosen_currency_makes_the_item_unavailable(): void
+    {
+        Currency::create(['code' => 'EUR', 'name' => 'Euro', 'prefix' => '&euro;', 'suffix' => '', 'format' => '1.000,00']);
+        $this->product->plan->prices()->create(['price' => 9.00, 'currency_code' => 'EUR']);
+
+        // The unit price only exists in USD
+        $option = $this->createNumberOption(0.05);
+
+        $price = $option->priceForQuantity(500, 1, 'month', 'EUR');
+
+        $this->assertFalse($price->available);
+        $this->assertEquals(0.0, $price->price);
+    }
+
+    public function test_a_coupon_discounts_the_per_unit_total(): void
+    {
+        $option = $this->createNumberOption(0.05, basePrice: 2.0);
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $coupon = Coupon::create([
+            'code' => 'HALF',
+            'type' => 'percentage',
+            'value' => 50,
+            'applies_to' => 'all',
+        ]);
+
+        Livewire::test('products.checkout', ['category' => $this->product->product->category, 'product' => $this->product->product->slug])
+            ->set('configOptions.' . $option->id, 500)
+            ->call('checkout');
+
+        Once::flush();
+
+        $cart = Cart::first();
+        $cart->update(['coupon_id' => $coupon->id]);
+
+        // 50% off the full 37.00, per-unit charges included
+        $this->assertEquals(18.5, (float) $cart->refresh()->items()->first()->price->price);
+    }
+
+    public function test_product_quantity_multiplies_the_per_unit_total(): void
+    {
+        $option = $this->createNumberOption(0.05, basePrice: 2.0);
+
+        Livewire::test('products.checkout', ['category' => $this->product->product->category, 'product' => $this->product->product->slug])
+            ->set('configOptions.' . $option->id, 500)
+            ->call('checkout');
+
+        Once::flush();
+
+        $item = Cart::first()->items()->first();
+        $item->update(['quantity' => 3]);
+
+        // Each unit of the product carries its own 37.00
+        $this->assertEquals(111.0, round($item->refresh()->price->total * $item->quantity, 2));
+    }
+
+    public function test_number_config_survives_a_service_upgrade(): void
+    {
+        $option = $this->createNumberOption(0.05, basePrice: 2.0);
+        $user = User::factory()->create();
+
+        $service = Service::factory()->create([
+            'user_id' => $user->id,
+            'plan_id' => $this->product->plan->id,
+            'product_id' => $this->product->product->id,
+            'status' => 'active',
+            'currency_code' => 'USD',
+            'price' => 10.00,
+        ]);
+        $service->configs()->create([
+            'config_option_id' => $option->id,
+            'config_value_id' => $option->children->first()->id,
+            'value' => 500,
+        ]);
+
+        $upgradeProduct = $this->createProduct(['name' => 'Test Product', 'slug' => 'upgrade-product']);
+
+        $upgrade = ServiceUpgrade::create([
+            'service_id' => $service->id,
+            'product_id' => $upgradeProduct->product->id,
+            'plan_id' => $upgradeProduct->plan->id,
+        ]);
+
+        (new ServiceUpgradeService)->handle($upgrade);
+
+        $this->assertDatabaseHas('service_configs', [
+            'configurable_id' => $service->id,
+            'config_option_id' => $option->id,
+            'value' => 500,
+        ]);
+    }
+
+    public function test_service_renewal_keeps_charging_per_unit(): void
+    {
+        $option = $this->createNumberOption(0.05, basePrice: 2.0);
+        $user = User::factory()->create();
+
+        $service = Service::factory()->create([
+            'user_id' => $user->id,
+            'plan_id' => $this->product->plan->id,
+            'product_id' => $this->product->product->id,
+            'status' => 'active',
+            'currency_code' => 'USD',
+            'price' => 10.00,
+        ]);
+
+        $service->configs()->create([
+            'config_option_id' => $option->id,
+            'config_value_id' => $option->children->first()->id,
+            'value' => 500,
+        ]);
+
+        $service->refresh();
+
+        // 10 (plan) + 2 (base) + 500 * 0.05 = 37
+        $this->assertEquals('37.00', $service->calculatePrice());
+    }
+}

--- a/tests/Feature/ConfigOptionUpgradeTest.php
+++ b/tests/Feature/ConfigOptionUpgradeTest.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ConfigOption;
+use App\Models\Plan;
+use App\Models\Price;
+use App\Models\Service;
+use App\Models\ServiceUpgrade;
+use App\Models\User;
+use App\Services\ServiceUpgrade\ServiceUpgradeService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ConfigOptionUpgradeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $product = null;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->product = $this->createProduct();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    /**
+     * A storage option at $0.05 per GB, upgradable, running from 100 to 5000 in steps of 10.
+     */
+    private function createStorageOption(array $attributes = []): ConfigOption
+    {
+        $option = ConfigOption::create(array_merge([
+            'name' => 'Storage',
+            'env_variable' => 'STORAGE',
+            'type' => 'number',
+            'min' => 100,
+            'max' => 5000,
+            'step' => 10,
+            'upgradable' => true,
+        ], $attributes));
+
+        $option->products()->attach($this->product->product->id);
+
+        $child = ConfigOption::create([
+            'name' => 'Price per GB',
+            'type' => 'number',
+            'parent_id' => $option->id,
+        ]);
+
+        $plan = Plan::factory()->create([
+            'priceable_id' => $child->id,
+            'priceable_type' => ConfigOption::class,
+            'name' => 'Test Plan',
+            'billing_unit' => 'month',
+            'billing_period' => 1,
+            'type' => 'recurring',
+        ]);
+        Price::factory()->create([
+            'plan_id' => $plan->id,
+            'price' => 0.05,
+            'currency_code' => 'USD',
+        ]);
+
+        return $option->refresh();
+    }
+
+    /**
+     * An active service holding $quantity GB, with $days left of its month.
+     */
+    private function createServiceWith(ConfigOption $option, $quantity, int $days = 14): Service
+    {
+        $service = Service::factory()->create([
+            'user_id' => $this->user->id,
+            'plan_id' => $this->product->plan->id,
+            'product_id' => $this->product->product->id,
+            'status' => 'active',
+            'currency_code' => 'USD',
+            'price' => 10.00,
+            'expires_at' => now()->addDays($days),
+        ]);
+
+        $service->configs()->create([
+            'config_option_id' => $option->id,
+            'config_value_id' => $option->children->first()->id,
+            'value' => $quantity,
+        ]);
+
+        return $service->refresh();
+    }
+
+    private function quote(Service $service, ConfigOption $option, $quantity): float
+    {
+        $upgrade = new ServiceUpgrade([
+            'service_id' => $service->id,
+            'product_id' => $service->product_id,
+            'plan_id' => $service->plan_id,
+        ]);
+        $upgrade->save();
+        $upgrade->configs()->create([
+            'config_option_id' => $option->id,
+            'config_value_id' => $option->children->first()->id,
+            'value' => $quantity,
+        ]);
+
+        return round((float) $upgrade->refresh()->calculatePrice()->price, 2);
+    }
+
+    public function test_upgrading_the_amount_is_prorated_over_the_remaining_days(): void
+    {
+        $option = $this->createStorageOption();
+        $service = $this->createServiceWith($option, 100, days: 14);
+
+        // (300 - 100) x $0.05 = $10.00 a month, of which 14 of 30 days remain
+        $this->assertEquals(4.67, $this->quote($service, $option, 300));
+    }
+
+    public function test_downgrading_the_amount_gives_a_prorated_credit(): void
+    {
+        $option = $this->createStorageOption();
+        $service = $this->createServiceWith($option, 300, days: 14);
+
+        $this->assertEquals(-4.67, $this->quote($service, $option, 100));
+    }
+
+    public function test_an_unchanged_amount_costs_nothing(): void
+    {
+        $option = $this->createStorageOption();
+        $service = $this->createServiceWith($option, 300, days: 14);
+
+        $this->assertEquals(0.0, $this->quote($service, $option, 300));
+    }
+
+    public function test_the_base_price_is_only_charged_when_the_option_is_added(): void
+    {
+        $option = $this->createStorageOption();
+
+        // $2.00 a month for having the option at all
+        $basePlan = Plan::factory()->create([
+            'priceable_id' => $option->id,
+            'priceable_type' => ConfigOption::class,
+            'name' => 'Base',
+            'billing_unit' => 'month',
+            'billing_period' => 1,
+            'type' => 'recurring',
+        ]);
+        Price::factory()->create([
+            'plan_id' => $basePlan->id,
+            'price' => 2.00,
+            'currency_code' => 'USD',
+        ]);
+        $option->refresh();
+
+        // Already on the service: the base price sits in both amounts and cancels out
+        $existing = $this->createServiceWith($option, 100, days: 14);
+        $this->assertEquals(4.67, $this->quote($existing, $option, 300));
+
+        // Added now: 300 x 0.05 + 2.00 = $17.00 a month, prorated over 14 of 30 days
+        $fresh = Service::factory()->create([
+            'user_id' => $this->user->id,
+            'plan_id' => $this->product->plan->id,
+            'product_id' => $this->product->product->id,
+            'status' => 'active',
+            'currency_code' => 'USD',
+            'price' => 10.00,
+            'expires_at' => now()->addDays(14),
+        ]);
+        $this->assertEquals(7.93, $this->quote($fresh->refresh(), $option, 300));
+    }
+
+    public function test_completing_the_upgrade_stores_the_new_amount_and_reprices_the_service(): void
+    {
+        $option = $this->createStorageOption();
+        $service = $this->createServiceWith($option, 100, days: 14);
+
+        $upgrade = new ServiceUpgrade([
+            'service_id' => $service->id,
+            'product_id' => $service->product_id,
+            'plan_id' => $service->plan_id,
+        ]);
+        $upgrade->save();
+        $upgrade->configs()->create([
+            'config_option_id' => $option->id,
+            'config_value_id' => $option->children->first()->id,
+            'value' => 300,
+        ]);
+
+        (new ServiceUpgradeService)->handle($upgrade->refresh());
+
+        $this->assertDatabaseHas('service_configs', [
+            'configurable_id' => $service->id,
+            'config_option_id' => $option->id,
+            'value' => 300,
+        ]);
+
+        // Renewals now cost 10 (plan) + 300 x 0.05 = 25
+        $this->assertEquals('25.00', $service->refresh()->calculatePrice());
+    }
+
+    public function test_upgrade_screen_starts_from_the_amount_the_customer_has(): void
+    {
+        $option = $this->createStorageOption();
+        $service = $this->createServiceWith($option, 300, days: 14);
+
+        Livewire::test('services.upgrade', ['service' => $service])
+            ->assertSet('configOptions.' . $option->id, '300')
+            ->assertSeeHtml('type="number"')
+            ->set('configOptions.' . $option->id, 500)
+            ->assertSeeText('Storage');
+    }
+
+    public function test_upgrade_screen_validates_the_range_and_increment(): void
+    {
+        $option = $this->createStorageOption();
+        $service = $this->createServiceWith($option, 100, days: 14);
+
+        $component = Livewire::test('services.upgrade', ['service' => $service]);
+
+        $component->set('configOptions.' . $option->id, 105)->call('doUpgrade')->assertHasErrors('configOptions.' . $option->id);
+        $component->set('configOptions.' . $option->id, 6000)->call('doUpgrade')->assertHasErrors('configOptions.' . $option->id);
+        $component->set('configOptions.' . $option->id, 300)->call('doUpgrade')->assertHasNoErrors();
+    }
+
+    public function test_the_customer_can_raise_the_amount_and_is_invoiced_the_difference(): void
+    {
+        $option = $this->createStorageOption();
+        $service = $this->createServiceWith($option, 100, days: 14);
+
+        Livewire::test('services.upgrade', ['service' => $service])
+            ->set('configOptions.' . $option->id, 300)
+            ->call('doUpgrade')
+            ->assertHasNoErrors();
+
+        $upgrade = ServiceUpgrade::where('service_id', $service->id)->first();
+
+        $this->assertNotNull($upgrade);
+        $this->assertEquals(300, (float) $upgrade->configs->first()->value);
+
+        // The invoice covers the 14 remaining days of the extra 200 GB, not a full month
+        $invoice = $upgrade->invoice;
+        $this->assertNotNull($invoice);
+        $this->assertEquals(4.67, round((float) $invoice->items->first()->price, 2));
+
+        // Nothing changes on the service until that invoice is settled
+        $this->assertEquals(100, (float) $service->refresh()->configs->first()->value);
+    }
+
+    public function test_submitting_the_same_amount_is_rejected_as_no_change(): void
+    {
+        $option = $this->createStorageOption();
+        $service = $this->createServiceWith($option, 300, days: 14);
+
+        Livewire::test('services.upgrade', ['service' => $service])
+            ->set('configOptions.' . $option->id, 300)
+            ->call('doUpgrade');
+
+        $this->assertDatabaseCount('service_upgrades', 0);
+    }
+
+    public function test_a_number_option_without_a_unit_price_is_not_upgradable(): void
+    {
+        $option = ConfigOption::create([
+            'name' => 'Nodes',
+            'env_variable' => 'NODES',
+            'type' => 'number',
+            'upgradable' => true,
+        ]);
+        $option->products()->attach($this->product->product->id);
+
+        $product = $this->product->product->refresh();
+
+        // Nothing to bill for, so it never reaches the upgrade screen and does not make the service upgradable
+        $this->assertFalse($product->upgradableConfigOptions->contains('id', $option->id));
+        $this->assertEquals(0, $product->upgradableConfigOptions()->count());
+
+        $service = Service::factory()->create([
+            'user_id' => $this->user->id,
+            'plan_id' => $this->product->plan->id,
+            'product_id' => $product->id,
+            'status' => 'active',
+            'currency_code' => 'USD',
+            'price' => 10.00,
+            'expires_at' => now()->addDays(14),
+        ]);
+
+        $this->assertFalse($service->refresh()->upgradable);
+    }
+
+    public function test_a_number_option_becomes_upgradable_once_it_has_a_unit_price(): void
+    {
+        $option = $this->createStorageOption();
+        $product = $this->product->product->refresh();
+
+        $this->assertTrue($product->upgradableConfigOptions->contains('id', $option->id));
+
+        $service = $this->createServiceWith($option, 100, days: 14);
+
+        $this->assertTrue($service->upgradable);
+
+        Livewire::test('services.upgrade', ['service' => $service])
+            ->assertSeeText('Storage');
+    }
+}

--- a/themes/default/views/components/form/configoption.blade.php
+++ b/themes/default/views/components/form/configoption.blade.php
@@ -76,11 +76,96 @@
             </div>
         @break
 
+        @case('number')
+            @php
+                $unitPrice = isset($config->children) && isset($plan)
+                    ? $config->children->first()?->price(billing_period: $plan->billing_period, billing_unit: $plan->billing_unit)
+                    : null;
+                $numberLabel = __($config->label ?? $config->name);
+                if (($showPriceTag ?? false) && $unitPrice?->available) {
+                    $numberLabel .= ' - ' . $unitPrice->formatted->price . ' ' . __('product.per_unit');
+                }
+                $numberMin = $config->min ?? null;
+                $numberMax = $config->max ?? null;
+                // A slider has to know where to start and stop, so it falls back to a plain input without a range
+                $asSlider = ($config->show_as_slider ?? false) && $numberMin !== null && $numberMax !== null;
+            @endphp
+            @if ($asSlider)
+                @php $sliderStep = ($config->step ?? null) ?: 1; @endphp
+                <div x-data="{
+                    value: @js((float) ($numberMin)),
+                    min: @js((float) $numberMin),
+                    max: @js((float) $numberMax),
+                    step: @js((float) $sliderStep),
+                    backendValue: $wire.entangle('{{ $name }}').live,
+
+                    init() {
+                        const initialValue = this.$wire.get('{{ $name }}');
+                        if (initialValue !== null && initialValue !== '') {
+                            this.value = Number(initialValue);
+                        }
+                        $watch('value', Alpine.debounce(() => this.backendValue = this.value, 300));
+                    },
+
+                    get progress() {
+                        if (this.max <= this.min) {
+                            return '100%';
+                        }
+                        const ratio = (this.value - this.min) / (this.max - this.min);
+
+                        return `${Math.min(100, Math.max(0, ratio * 100))}%`;
+                    },
+                }" class="flex flex-col gap-1">
+                    <label for="{{ $name }}" class="mb-1 text-sm text-primary-100">
+                        {{ $numberLabel }}
+                        @if ($config->required ?? false)
+                            <span class="text-red-500">*</span>
+                        @endif
+                    </label>
+                    <div class="flex flex-row items-center gap-3" wire:ignore>
+                        <div class="relative flex items-center grow" :style="`--progress:${progress}`">
+                            <div class="
+                                absolute left-2.5 right-2.5 h-1.5 bg-background-secondary rounded-full overflow-hidden
+                                before:absolute before:inset-0 before:bg-primary
+                                before:[mask-image:_linear-gradient(to_right,theme(colors.white),theme(colors.white)_var(--progress),transparent_var(--progress))]
+                                [&[x-cloak]]:hidden" aria-hidden="true" x-cloak></div>
+                            <input class="
+                                relative appearance-none cursor-pointer w-full bg-transparent focus:outline-none
+                                [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5
+                                [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-none
+                                [&::-webkit-slider-thumb]:focus:ring-0 [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5
+                                [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-base [&::-moz-range-thumb]:border-none
+                                [&::-moz-range-thumb]:shadow-none [&::-moz-range-thumb]:focus:ring-0
+                            " type="range" min="{{ $numberMin + 0 }}" max="{{ $numberMax + 0 }}" step="{{ $sliderStep + 0 }}"
+                                x-model.number="value" aria-label="{{ $config->label ?? $config->name }}" name="{{ $name }}"
+                                id="{{ $name }}" />
+                        </div>
+                        {{-- The slider alone cannot hit an exact amount over a long range, so the number stays editable --}}
+                        <input type="number"
+                            class="block w-28 shrink-0 text-sm text-base bg-background-secondary border border-neutral rounded-md shadow-sm focus:outline-none transition-all duration-300 ease-in-out px-2.5 py-2.5"
+                            min="{{ $numberMin + 0 }}" max="{{ $numberMax + 0 }}" step="{{ $sliderStep + 0 }}"
+                            x-model.number="value" aria-label="{{ $config->label ?? $config->name }}" />
+                    </div>
+                    <div class="flex justify-between text-xs text-primary-500 px-2.5">
+                        <span>{{ $numberMin + 0 }}</span>
+                        <span>{{ $numberMax + 0 }}</span>
+                    </div>
+                    @error($name)
+                        <p class="text-red-500 text-xs">{{ $message }}</p>
+                    @enderror
+                </div>
+            @else
+                <x-form.input name="{{ $name }}" type="number" :label="$numberLabel"
+                    :required="$config->required ?? false" wire:model.live.debounce.500ms="{{ $name }}"
+                    :placeholder="$config->placeholder ?? ($config->default ?? '')" :min="$numberMin"
+                    :max="$numberMax" :step="$config->step ?? 'any'" />
+            @endif
+        @break
+
         @case('text')
         @case('password')
 
         @case('email')
-        @case('number')
 
         @case('color')
         @case('file')


### PR DESCRIPTION
## Summary

Closes #1227.

Right now the only config option type that scales price with quantity is **Slider**, and a slider needs one child row per value. Offering storage from 100 GB to 5000 GB in steps of 10 means creating 491 children by hand, so in practice nobody offers it.

This gives the **Number** type its own pricing:

- **Base price** — optional, charged once per cycle
- **Price per unit** — multiplied by what the customer types
- **Min / max / increment** — bounds the range
- **Show as slider** — optional, off by default

RAM at €0.75/unit, customer enters `8`, €6.00 gets added.

Nothing new was invented for the pricing itself. The option's own plans hold the base price, and its single child's plans hold the unit price — the same shape `checkbox` already uses — so multi-currency, billing cycles, setup fees and free plans all keep working. Everything resolves through `ConfigOption::priceForQuantity()`, called from checkout, cart, renewals and upgrades.

## Renewals

A priced number option is now stored as a service config with the ordered amount in the new `service_configs.value` column, instead of as a service property. Properties carry no price, so without this the customer would pay at checkout and never again. `getServiceProperties()` unwraps it, so server modules still get the amount under the option's env variable.

Unpriced number options are untouched and still write a property.

## Upgrades

Number options can be flagged upgradable. 100 GB → 300 GB at €0.05 with 14 days left of a 30 day cycle invoices `14/30 × (300−100) × 0.05` = 4.67, and downgrades credit through the existing `credits_on_downgrade` path.

`calculateProratedAmount()` short-circuits to zero when old and new are the same model, which is always true here since only the quantity changes — so quantity upgrades go through `calculateProratedQuantityAmount()`, which diffs the two resolved prices instead.

Two things I had to change while wiring this up:

- `ServiceUpgradeService::handle()` was deleting configs not present in the upgrade payload, which would have wiped non-upgradable number options and silently dropped their charge from renewals.
- The "you have not changed anything" guard compared quantities against child ids, so it could never match for number options and let unchanged upgrades through as no-op records.

`Product::upgradableConfigOptions()` now also excludes number options with no unit price — there's nothing to bill for, and otherwise a service looks upgradable but the upgrade page is empty.

## Compatibility

All four new columns are nullable or defaulted. An existing number option with no price attached behaves exactly as before. I tested the migration against a database with pre-existing config options and services — everything survives and prices identically.

## Tests

27 new tests covering pricing, validation, cart, order, renewal, upgrade proration both directions, setup fees per unit, missing currency, coupons and quantity. Suite passes on SQLite and MariaDB.

## Tests
