### PR TITLE
Add hook('pages.security') slot to security page

### DIFF
--- a/themes/default/views/client/account/security.blade.php
+++ b/themes/default/views/client/account/security.blade.php
@@ -91,4 +91,5 @@
             @endif
         </div>
     </div>
+    {!! hook('pages.security') !!}
 </div>


### PR DESCRIPTION
## Summary

Adds a single `{!! hook('pages.security') !!}` slot to the bundled default theme's client Security page, matching the existing hook pattern already used elsewhere in the theme.

## Motivation

Paymenter already exposes hook slots on several client pages so extensions can inject UI without patching core files:

- `themes/default/views/dashboard.blade.php:86` — `hook('pages.dashboard')`
- `themes/default/views/home.blade.php:51` — `hook('pages.home')`
- Layouts (`head`, `body`, `footer`)

The Security page is a natural home for **connected-account widgets** (Discord, Google, Slack, GitHub, etc.), but it currently has no hook slot, so any extension that wants to add a "Link Discord" / "Connect Google" / etc. section is forced to either fork the theme or ship a patched blade file.

## What this PR does

- Adds one line to `themes/default/views/client/account/security.blade.php`, placed inside the outer container after the existing session/password/2FA cards, mirroring the placement of `hook('pages.home')` in `home.blade.php`.

Diff is exactly **1 file, +1 line**.

## Example extension usage

```php
// In an extension's ServiceProvider or hook registration
add_action('pages.security', function () {
    return view('discord-link::security-widget'); // "Link your Discord account" card
});
```

## Risk

Zero. `hook()` returns an empty string when nothing is listening, so behaviour is identical to today for installs with no extensions using this slot.

## Notes

- This only touches the bundled `default` theme. The Luna theme lives in a separate repo and can adopt the same slot independently.
- No JS/CSS changes, no controller changes, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)