### PR TITLE
feat: add suspend_hold_until to services to pause automatic suspension

### DIFF
--- a/app/Admin/Resources/ServiceResource.php
+++ b/app/Admin/Resources/ServiceResource.php
@@ -98,6 +98,12 @@ class ServiceResource extends Resource
                     ->label('Expires At')
                     ->required(fn (Get $get) => $get('plan')?->type != 'one-time' && $get('plan')?->type != 'free' && $get('status') !== 'pending')
                     ->placeholder('Select the expiration date'),
+                DatePicker::make('suspend_hold_until')
+                    ->label('Do Not Suspend Until')
+                    ->helperText('While set to a future date, the automatic suspension cronjob will skip this service, even if it is overdue. This does not affect manual suspension or termination.')
+                    ->minDate(now())
+                    ->nullable()
+                    ->placeholder('Select a date to hold off suspension until'),
                 Select::make('coupon_id')
                     ->label('Coupon')
                     ->relationship('coupon', 'code')

--- a/app/Console/Commands/CronJob.php
+++ b/app/Console/Commands/CronJob.php
@@ -170,12 +170,17 @@ class CronJob extends Command
 
             $this->runCronJob('services_suspended', function ($number = 0) {
                 // Suspend orders if due date is overdue for x days
-                Service::where('status', 'active')->where('expires_at', '<', now()->subDays((int) config('settings.cronjob_order_suspend', 2)))->get()->each(function ($service) use (&$number) {
-                    SuspendJob::dispatch($service);
+                Service::where('status', 'active')
+                    ->where('expires_at', '<', now()->subDays((int) config('settings.cronjob_order_suspend', 2)))
+                    ->where(function ($query) {
+                        $query->whereNull('suspend_hold_until')->orWhere('suspend_hold_until', '<', now());
+                    })
+                    ->get()->each(function ($service) use (&$number) {
+                        SuspendJob::dispatch($service);
 
-                    $service->update(['status' => 'suspended']);
-                    $number++;
-                });
+                        $service->update(['status' => 'suspended']);
+                        $number++;
+                    });
 
                 return $number;
             });

--- a/app/Http/Requests/Api/Admin/Services/CreateServiceRequest.php
+++ b/app/Http/Requests/Api/Admin/Services/CreateServiceRequest.php
@@ -35,6 +35,7 @@ class CreateServiceRequest extends AdminApiRequest
              */
             'status' => 'required|in:pending,active,cancelled,suspended',
             'expires_at' => 'nullable|date|after_or_equal:today',
+            'suspend_hold_until' => 'nullable|date|after_or_equal:today',
             /**
              * @example USD
              */

--- a/app/Http/Requests/Api/Admin/Services/UpdateServiceRequest.php
+++ b/app/Http/Requests/Api/Admin/Services/UpdateServiceRequest.php
@@ -35,6 +35,7 @@ class UpdateServiceRequest extends AdminApiRequest
              */
             'status' => 'sometimes|required|in:pending,active,cancelled,suspended',
             'expires_at' => 'sometimes|nullable|date|after_or_equal:today',
+            'suspend_hold_until' => 'sometimes|nullable|date|after_or_equal:today',
             /**
              * @example USD
              */

--- a/app/Http/Resources/ServiceResource.php
+++ b/app/Http/Resources/ServiceResource.php
@@ -13,6 +13,7 @@ class ServiceResource extends JsonApiResource
         'status',
         'currency_code',
         'expires_at',
+        'suspend_hold_until',
         'updated_at',
         'created_at',
     ];

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -37,10 +37,12 @@ class Service extends Model implements Auditable
         'user_id',
         'currency_code',
         'billing_agreement_id',
+        'suspend_hold_until',
     ];
 
     protected $casts = [
         'expires_at' => 'date',
+        'suspend_hold_until' => 'date',
     ];
 
     /**

--- a/database/migrations/2026_08_27_000000_add_suspend_hold_until_to_services.php
+++ b/database/migrations/2026_08_27_000000_add_suspend_hold_until_to_services.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('services', function (Blueprint $table) {
+            $table->date('suspend_hold_until')->nullable()->after('expires_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('services', function (Blueprint $table) {
+            $table->dropColumn('suspend_hold_until');
+        });
+    }
+};


### PR DESCRIPTION
Adds a nullable suspend_hold_until date field to services. When set to a future date, the services_suspended cronjob skips the service even if its expiration is overdue, without disabling suspension globally. Manual suspension via the admin panel or API is unaffected.

Settable from the admin service edit page and via the admin API.