### PR TITLE
themes: register theme view path with Blade's anonymous component resolver

### DIFF
--- a/app/Providers/SettingsProvider.php
+++ b/app/Providers/SettingsProvider.php
@@ -6,6 +6,7 @@ use App\Classes\Settings;
 use App\Models\Setting;
 use Exception;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Lang;
@@ -60,6 +61,14 @@ class SettingsProvider extends ServiceProvider
 
             $themeName = config('settings.theme', 'default');
             Theme::set($themeName, 'default');
+
+            // Register the active theme's view path with Blade's anonymous
+            // component resolver so <x-foo> can find files at any depth
+            // inside themes/<active>/views (e.g. <x-layouts.auth>).
+            $themeViewPath = base_path("themes/{$themeName}/views");
+            if (is_dir($themeViewPath)) {
+                Blade::anonymousComponentPath($themeViewPath);
+            }
 
             $themeLangPath = base_path("themes/{$themeName}/lang");
             if (is_dir($themeLangPath)) {


### PR DESCRIPTION
## Problem

Paymenter themes can override **page layouts** (e.g. `themes/<name>/views/layouts/app.blade.php`), and the Qirolab themer makes those resolvable via Laravel's view finder. However, **Blade anonymous components** resolve through a *separate* list of paths (`BladeCompiler$$anonymousComponentPaths`), which is seeded only with `resources/views/components`.

As a result, theme components that live outside `views/components/` fail at render time:

```
Unable to locate a class or view for component [layouts.auth].
```

Any theme that ships a component at a non-`components/` path (layouts, partials, etc.) needs a custom patch today.

## Fix

In `SettingsProvider::getSettings()`, right after `Theme::set()`, register the active theme's views directory with Blade's anonymous component resolver:

```php
$themeViewPath = base_path("themes/{$themeName}/views");
if (is_dir($themeViewPath)) {
    Blade::anonymousComponentPath($themeViewPath);
}
```

Now any file at any depth inside the active theme resolves as `<x-…>` (e.g. `<x-layouts.auth>` → `themes/<active>/views/layouts/auth.blade.php`).

## Notes

- No behavior change for the bundled `default` theme — its components already live under `views/components/` and resolve unchanged.
- The guard is a cheap `is_dir()` check; no-op when no theme views directory exists.
- No config, no new public API, no migration.
- Tested with a custom theme (100+ views) on Laravel 12 / Livewire 3 / Blade 4: all routes render, including auth layouts and error pages.