### PR TITLE
Update ServiceResource.php

### DIFF
--- a/app/Http/Resources/ServiceResource.php
+++ b/app/Http/Resources/ServiceResource.php
@@ -16,6 +16,7 @@ class ServiceResource extends JsonApiResource
         'suspend_hold_until',
         'updated_at',
         'created_at',
+        'label',
     ];
 
     public $relationships = [


### PR DESCRIPTION
### Description
This pull request adds the `label` field to the `$attributes` array in `ServiceResource`.

### Problem
The `services` database table already contains the `label` column, but it was previously omitted from `ServiceResource`, making it unavailable when querying services via the API.

### Solution
Added `'label'` to `$attributes` in `app/Http/Resources/ServiceResource.php` so the service label/custom name is properly serialized and returned in JSON:API responses.