### PR TITLE
fix: use unambiguous date formats for cancellation notice and invoice PDFs

### DIFF
--- a/resources/views/admin/resources/service-resource/widgets/cancellation-overview.blade.php
+++ b/resources/views/admin/resources/service-resource/widgets/cancellation-overview.blade.php
@@ -5,7 +5,7 @@
         <p class="text-sm text-gray-950 dark:text-white">This service is cancelled. Reason: <span class="font-medium">{{$record->cancellation->reason }}</span></p>
         @else
         <p class="text-sm text-gray-950 dark:text-white">This service is pending cancellation{{ $record->expires_at ? ' on ' .
-            $record->expires_at->format('d-m-Y') : '' }}. Reason: <span class="font-medium">{{
+            $record->expires_at->translatedFormat('M j, Y') : '' }}. Reason: <span class="font-medium">{{
                 $record->cancellation->reason }}</span>
         </p>
         @endif

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -136,7 +136,7 @@
             </td>
         </tr>
     </table>
-    <p>{{ !$invoice->number && config('settings.invoice_proforma', false) ? __('invoices.proforma_invoice_date') : __('invoices.invoice_date') }}: <strong>{{ $invoice->created_at->format('d/m/Y') }}</strong></p>
+    <p>{{ !$invoice->number && config('settings.invoice_proforma', false) ? __('invoices.proforma_invoice_date') : __('invoices.invoice_date') }}: <strong>{{ $invoice->created_at->translatedFormat('d M Y') }}</strong></p>
     @if($invoice->number)
     <p>{{ __('invoices.invoice_no') }}: <strong>{{ $invoice->number }}</strong></p>
     @endif
@@ -207,7 +207,7 @@
             @foreach($invoice->transactions->where('status', \App\Enums\InvoiceTransactionStatus::Succeeded) as $transaction)
             <tr>
                 <td>{{ $transaction->transaction_id }}</td>
-                <td>{{ $transaction->created_at->format('d/m/Y') }}</td>
+                <td>{{ $transaction->created_at->translatedFormat('d M Y') }}</td>
                 <td>{{ $transaction->formattedAmount }}</td>
                 <td>{{ $transaction->gateway ? $transaction->gateway->name : '' }}</td>
             </tr>


### PR DESCRIPTION
Making Paymenter a little more friendly for Americans by adopting translated date format in missing places (admin service cancellation pending notice and invoice PDFs).

**Before:**
<img width="940" height="236" alt="1" src="https://github.com/user-attachments/assets/1d7d489b-0af8-42a2-9189-edf9e8c87c55" />
<img width="828" height="48" alt="2" src="https://github.com/user-attachments/assets/47661207-84f1-43f4-a9ef-91ab7751e973" />


**After:**
<img width="731" height="187" alt="3" src="https://github.com/user-attachments/assets/38d8d3f7-8c73-4dac-847f-32168c70da4f" />
<img width="1117" height="64" alt="4" src="https://github.com/user-attachments/assets/b966a4be-55f2-42dc-9899-110bf171269f" />
