### PR TITLE
fix(admin): dashboard overview stats follow the revenue chart period, ticket trend color inverted

### DIFF
--- a/app/Admin/Widgets/Overview.php
+++ b/app/Admin/Widgets/Overview.php
@@ -22,7 +22,8 @@ class Overview extends BaseWidget
     {
         return [
             $this->invoiceTransaction(),
-            $this->getData(Ticket::class, 'Tickets'),
+            // Fewer new tickets is the good outcome here, so the trend color is inverted
+            $this->getData(Ticket::class, 'Tickets', lowerIsBetter: true),
             $this->getData(Service::class, 'Services'),
         ];
     }
@@ -40,13 +41,13 @@ class Overview extends BaseWidget
         return $this->stat('Revenue', $chart, $previous);
     }
 
-    private function getData(string $model, string $name): Stat
+    private function getData(string $model, string $name, bool $lowerIsBetter = false): Stat
     {
         $chart = $this->trend(Trend::model($model))->count();
 
         $previous = $this->previousPeriod($model::query())->count();
 
-        return $this->stat($name, $chart, $previous);
+        return $this->stat($name, $chart, $previous, $lowerIsBetter);
     }
 
     private function trend(Trend $trend): Trend
@@ -71,7 +72,7 @@ class Overview extends BaseWidget
             ->where('created_at', '<', $start);
     }
 
-    private function stat(string $label, Collection $chart, float|int $previous): Stat
+    private function stat(string $label, Collection $chart, float|int $previous, bool $lowerIsBetter = false): Stat
     {
         $current = $chart->sum('aggregate');
 
@@ -79,11 +80,13 @@ class Overview extends BaseWidget
 
         $percentage = $previous > 0 ? (abs($change) / $previous) * 100 : 0;
 
+        $isPositive = $lowerIsBetter ? $change <= 0 : $change >= 0;
+
         return Stat::make($label, $current)
             ->description(($change >= 0 ? 'Increased by ' : 'Decreased by ') . number_format($percentage, 2) . '% (last 30 days)')
             ->descriptionIcon($change >= 0 ? 'heroicon-m-arrow-trending-up' : 'heroicon-m-arrow-trending-down')
             ->chart($chart->map(fn (TrendValue $value) => $value->aggregate)->toArray())
-            ->color($change >= 0 ? 'success' : 'danger');
+            ->color($isPositive ? 'success' : 'danger');
     }
 
     public static function canView(): bool

--- a/app/Admin/Widgets/Overview.php
+++ b/app/Admin/Widgets/Overview.php
@@ -2,6 +2,7 @@
 
 namespace App\Admin\Widgets;
 
+use App\Enums\DashboardPeriod;
 use App\Enums\InvoiceTransactionStatus;
 use App\Models\InvoiceTransaction;
 use App\Models\Service;
@@ -12,17 +13,26 @@ use Flowframe\Trend\Trend;
 use Flowframe\Trend\TrendValue;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Livewire\Attributes\On;
 
 class Overview extends BaseWidget
 {
     // Poll every 5 minutes (5m doesn't work somehow)
     protected ?string $pollingInterval = '600s';
 
+    public ?string $period = null;
+
+    #[On('dashboard-period-updated')]
+    public function updatePeriod(string $period): void
+    {
+        $this->period = $period;
+    }
+
     protected function getStats(): array
     {
         return [
             $this->invoiceTransaction(),
-            // Fewer new tickets is the good outcome here, so the trend color is inverted
+            // Fewer new tickets is the good outcome, so the trend color is inverted
             $this->getData(Ticket::class, 'Tickets', lowerIsBetter: true),
             $this->getData(Service::class, 'Services'),
         ];
@@ -50,14 +60,19 @@ class Overview extends BaseWidget
         return $this->stat($name, $chart, $previous, $lowerIsBetter);
     }
 
+    private function period(): DashboardPeriod
+    {
+        return DashboardPeriod::fromValue($this->period);
+    }
+
     private function trend(Trend $trend): Trend
     {
         return $trend
             ->between(
-                start: now()->subMonth()->startOfDay(),
+                start: $this->period()->start(),
                 end: now(),
             )
-            ->perDay();
+            ->interval($this->period()->interval());
     }
 
     /**
@@ -65,10 +80,10 @@ class Overview extends BaseWidget
      */
     private function previousPeriod(Builder $query): Builder
     {
-        $start = now()->subMonth()->startOfDay();
+        $start = $this->period()->start();
 
         return $query
-            ->where('created_at', '>=', $start->copy()->subMonth()->startOfDay())
+            ->where('created_at', '>=', $this->period()->start($start))
             ->where('created_at', '<', $start);
     }
 
@@ -80,13 +95,16 @@ class Overview extends BaseWidget
 
         $percentage = $previous > 0 ? (abs($change) / $previous) * 100 : 0;
 
-        $isPositive = $lowerIsBetter ? $change <= 0 : $change >= 0;
+        $color = ($lowerIsBetter ? $change <= 0 : $change >= 0) ? 'success' : 'danger';
 
         return Stat::make($label, $current)
-            ->description(($change >= 0 ? 'Increased by ' : 'Decreased by ') . number_format($percentage, 2) . '% (last 30 days)')
+            // The sparkline only reads its color when Alpine initializes it, so key the stat on the
+            // color to make Livewire replace the element when it changes (filamentphp/filament#13518)
+            ->key("{$label}-{$color}")
+            ->description(($change >= 0 ? 'Increased by ' : 'Decreased by ') . number_format($percentage, 2) . '% (' . strtolower($this->period()->label()) . ')')
             ->descriptionIcon($change >= 0 ? 'heroicon-m-arrow-trending-up' : 'heroicon-m-arrow-trending-down')
             ->chart($chart->map(fn (TrendValue $value) => $value->aggregate)->toArray())
-            ->color($isPositive ? 'success' : 'danger');
+            ->color($color);
     }
 
     public static function canView(): bool

--- a/app/Admin/Widgets/Overview.php
+++ b/app/Admin/Widgets/Overview.php
@@ -10,7 +10,8 @@ use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Flowframe\Trend\Trend;
 use Flowframe\Trend\TrendValue;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 
 class Overview extends BaseWidget
 {
@@ -26,59 +27,63 @@ class Overview extends BaseWidget
         ];
     }
 
-    private function invoiceTransaction()
+    private function invoiceTransaction(): Stat
     {
-        $chart = Trend::query(InvoiceTransaction::query()->where('status', InvoiceTransactionStatus::Succeeded)->where('is_credit_transaction', false))
-            ->between(
-                start: now()->subMonth()->startOfDay(),
-                end: now(),
-            )
-            ->perDay()->sum('amount');
+        $query = InvoiceTransaction::query()
+            ->where('status', InvoiceTransactionStatus::Succeeded)
+            ->where('is_credit_transaction', false);
 
-        $thisMonth = $chart->sum('aggregate');
+        $chart = $this->trend(Trend::query(clone $query))->sum('amount');
 
-        $lastMonth = InvoiceTransaction::query()
-            ->whereBetween('created_at', [now()->subMonths(2)->startOfDay(), now()->subMonth()->endOfDay()])
-            ->sum('amount');
+        $previous = $this->previousPeriod(clone $query)->sum('amount');
 
-        $increase = $thisMonth - $lastMonth;
-
-        $percentageIncrease = $lastMonth > 0 ? (($thisMonth - $lastMonth) / $lastMonth) * 100 : 0;
-
-        return Stat::make('Revenue', $thisMonth)
-            ->description($increase >= 0 ? 'Increased by ' . number_format($percentageIncrease, 2) . '% (last 30 days)' : 'Decreased by ' . number_format($percentageIncrease, 2) . '% (last 30 days)')
-            ->descriptionIcon($increase >= 0 ? 'heroicon-m-arrow-trending-up' : 'heroicon-m-arrow-trending-down')
-            ->chart($chart->map(fn (TrendValue $value) => $value->aggregate)->toArray())
-            ->color($increase >= 0 ? 'success' : 'danger');
+        return $this->stat('Revenue', $chart, $previous);
     }
 
-    private function getData($model, $name, $sum = false)
+    private function getData(string $model, string $name): Stat
     {
-        $model = $model instanceof Model ? get_class($model) : $model;
+        $chart = $this->trend(Trend::model($model))->count();
 
-        $chart = Trend::model($model)
+        $previous = $this->previousPeriod($model::query())->count();
+
+        return $this->stat($name, $chart, $previous);
+    }
+
+    private function trend(Trend $trend): Trend
+    {
+        return $trend
             ->between(
                 start: now()->subMonth()->startOfDay(),
                 end: now(),
             )
-            ->perDay()
-            ->count();
+            ->perDay();
+    }
 
-        $thisMonth = $chart->sum('aggregate');
+    /**
+     * Scope the query to the period directly before the one shown, without overlapping it.
+     */
+    private function previousPeriod(Builder $query): Builder
+    {
+        $start = now()->subMonth()->startOfDay();
 
-        $lastMonth = $model::query()
-            ->whereBetween('created_at', [now()->subMonths(2)->startOfDay(), now()->subMonth()->endOfDay()])
-            ->count();
+        return $query
+            ->where('created_at', '>=', $start->copy()->subMonth()->startOfDay())
+            ->where('created_at', '<', $start);
+    }
 
-        $increase = $thisMonth - $lastMonth;
+    private function stat(string $label, Collection $chart, float|int $previous): Stat
+    {
+        $current = $chart->sum('aggregate');
 
-        $percentageIncrease = $lastMonth > 0 ? (($thisMonth - $lastMonth) / $lastMonth) * 100 : 0;
+        $change = $current - $previous;
 
-        return Stat::make($name, $thisMonth)
-            ->description($increase >= 0 ? 'Increased by ' . number_format($percentageIncrease, 2) . '% (last 30 days)' : 'Decreased by ' . number_format($percentageIncrease, 2) . '% (last 30 days)')
-            ->descriptionIcon($increase >= 0 ? 'heroicon-m-arrow-trending-up' : 'heroicon-m-arrow-trending-down')
+        $percentage = $previous > 0 ? (abs($change) / $previous) * 100 : 0;
+
+        return Stat::make($label, $current)
+            ->description(($change >= 0 ? 'Increased by ' : 'Decreased by ') . number_format($percentage, 2) . '% (last 30 days)')
+            ->descriptionIcon($change >= 0 ? 'heroicon-m-arrow-trending-up' : 'heroicon-m-arrow-trending-down')
             ->chart($chart->map(fn (TrendValue $value) => $value->aggregate)->toArray())
-            ->color($increase >= 0 ? 'success' : 'danger');
+            ->color($change >= 0 ? 'success' : 'danger');
     }
 
     public static function canView(): bool

--- a/app/Admin/Widgets/Revenue.php
+++ b/app/Admin/Widgets/Revenue.php
@@ -2,6 +2,7 @@
 
 namespace App\Admin\Widgets;
 
+use App\Enums\DashboardPeriod;
 use App\Enums\InvoiceTransactionStatus;
 use App\Models\InvoiceTransaction;
 use App\Models\Order;
@@ -15,44 +16,39 @@ class Revenue extends ChartWidget
 {
     protected ?string $heading = 'Revenue';
 
-    public ?string $filter = 'week';
+    public ?string $filter = 'month';
 
     protected ?string $pollingInterval = null;
 
     protected function getFilters(): ?array
     {
-        return [
-            'today' => 'Last 24 hours',
-            'week' => 'Last 7 days',
-            'month' => 'Last 30 days',
-            'year' => 'Last 365 days',
-        ];
+        return DashboardPeriod::options();
+    }
+
+    /**
+     * Let the overview stats follow the period chosen here.
+     */
+    public function updatedFilter(): void
+    {
+        $this->dispatch('dashboard-period-updated', period: $this->filter);
     }
 
     protected function getData(): array
     {
-        $start = match ($this->filter) {
-            'today' => now()->subDay()->startOfDay(),
-            'week' => now()->subWeek()->startOfDay(),
-            'month' => now()->subMonth()->startOfDay(),
-            'year' => now()->subYear()->startOfDay(),
-        };
+        $period = DashboardPeriod::fromValue($this->filter);
+
+        $start = $period->start();
 
         $end = now();
 
-        $per = match ($this->filter) {
-            'today' => 'hour',
-            'week' => 'day',
-            'month' => 'day',
-            'year' => 'month',
-        };
+        $interval = $period->interval();
 
         $revenue = Trend::query(InvoiceTransaction::query()->where('status', InvoiceTransactionStatus::Succeeded)->where('is_credit_transaction', false))
             ->between(
                 start: $start,
                 end: $end,
             )
-            ->{'per' . ucfirst($per)}()
+            ->interval($interval)
             ->sum('amount');
 
         $netRevenue = Trend::query(InvoiceTransaction::query()->where('status', InvoiceTransactionStatus::Succeeded)->where('is_credit_transaction', false))
@@ -60,7 +56,7 @@ class Revenue extends ChartWidget
                 start: $start,
                 end: $end,
             )
-            ->{'per' . ucfirst($per)}()
+            ->interval($interval)
             ->sum('amount - COALESCE(fee, 0)');
 
         $newOrders = Trend::model(Order::class)
@@ -68,7 +64,7 @@ class Revenue extends ChartWidget
                 start: $start,
                 end: $end,
             )
-            ->{'per' . ucfirst($per)}()
+            ->interval($interval)
             ->count();
 
         return [
@@ -92,11 +88,7 @@ class Revenue extends ChartWidget
                     'borderColor' => '#e3342f',
                 ],
             ],
-            'labels' => $revenue->map(fn (TrendValue $value) => match ($this->filter) {
-                'today' => Carbon::parse($value->date)->format('H:i'),
-                'year' => Carbon::parse($value->date)->format('M'),
-                default => Carbon::parse($value->date)->format('M d'),
-            })->toArray(),
+            'labels' => $revenue->map(fn (TrendValue $value) => Carbon::parse($value->date)->format($period->dateFormat()))->toArray(),
         ];
     }
 

--- a/app/Enums/DashboardPeriod.php
+++ b/app/Enums/DashboardPeriod.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Enums;
+
+use Carbon\CarbonInterface;
+
+enum DashboardPeriod: string
+{
+    case Day = 'today';
+    case Week = 'week';
+    case Month = 'month';
+    case Year = 'year';
+
+    public static function default(): self
+    {
+        return self::Month;
+    }
+
+    /**
+     * Resolve a period from user input, falling back to the default for unknown values.
+     */
+    public static function fromValue(?string $value): self
+    {
+        return self::tryFrom((string) $value) ?? self::default();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function options(): array
+    {
+        return collect(self::cases())
+            ->mapWithKeys(fn (self $period) => [$period->value => $period->label()])
+            ->all();
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Day => 'Last 24 hours',
+            self::Week => 'Last 7 days',
+            self::Month => 'Last 30 days',
+            self::Year => 'Last 365 days',
+        };
+    }
+
+    /**
+     * Start of this period, counted back from $from (defaults to now).
+     * Passing the start of the current period gives the start of the previous one.
+     */
+    public function start(?CarbonInterface $from = null): CarbonInterface
+    {
+        $from = ($from ?? now())->copy();
+
+        return match ($this) {
+            self::Day => $from->subDay()->startOfDay(),
+            self::Week => $from->subWeek()->startOfDay(),
+            self::Month => $from->subMonth()->startOfDay(),
+            self::Year => $from->subYear()->startOfDay(),
+        };
+    }
+
+    /**
+     * Bucket size used by laravel-trend for this period.
+     */
+    public function interval(): string
+    {
+        return match ($this) {
+            self::Day => 'hour',
+            self::Week, self::Month => 'day',
+            self::Year => 'month',
+        };
+    }
+
+    /**
+     * Date format for chart axis labels.
+     */
+    public function dateFormat(): string
+    {
+        return match ($this) {
+            self::Day => 'H:i',
+            self::Year => 'M',
+            default => 'M d',
+        };
+    }
+}


### PR DESCRIPTION
On the admin dashboard, the three overview stats (Revenue, Tickets, Services) and the Revenue chart don't agree with each other, and the stat comparisons have a few small bugs.

- The stats are hardcoded to the last 30 days while the Revenue chart defaults to the last 7 days. Changing the chart's period does nothing to the stats, so a reader looking at a 365-day chart still sees 30-day figures above it.
- The Tickets stat is colored like Revenue and Services, where more new tickets shows green with an uptrend arrow. However, fewer tickets is the good outcome.
- The previous-period revenue used for the percentage isn't filtered to succeeded, non-credit transactions like the current period is, so the comparison mixes in failed and credit transactions.
- The previous window overlapped the current one by a day.
- A decline read "Decreased by -41.63%".

## Changes

1. **Consistent previous-period comparison.** Same status/credit filters on both sides, previous window ends exclusively where the current one starts, percentage is absolute. The three stats now share one helper.
2. **Tickets trend inverted.** Fewer new tickets than the previous period is green. The arrow still points in the real direction of the change.
3. **Stats follow the chart period.** The chart dropdown now defaults to 30 days and broadcasts a Livewire event when changed; the overview widget listens and recomputes for the same period (24 hours, 7 days, 30 days, 365 days), and each description echoes the selected period. The period definitions (label, start, trend interval, axis date format) live in a small `DashboardPeriod` enum so the two widgets can't drift apart.

Each stat is also keyed on its color. The stat sparkline only reads its color when Alpine initialises it (filamentphp/filament#13518), so after an in-place Livewire morph a stat that flipped from green to red kept a green line. With the color in the `wire:key`, Livewire replaces the element and the line is redrawn in the right color.

## Notes

- Default period for both the chart and the stats is now 30 days (was 7 for the chart).
- When the previous period has no data the description still reads "Increased by 0.00%" as before; left unchanged to keep this PR small.
- The ticket resource page's overview colors Open tickets green and Closed red, which has the same inverted logic. Not touched here.

## Testing

Verified on a production instance against the previous 30-day figures (revenue, tickets, services all match), then switched between all four periods and checked the numbers, descriptions, arrow direction, colors, and sparkline colors.